### PR TITLE
Fix git lines added/removed not being shortened in summary line

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -42,6 +42,7 @@ from .tui_helpers import (
     format_ago,
     format_duration,
     format_tokens,
+    format_line_count,
     calculate_uptime,
     presence_state_to_char,
     agent_status_to_char,
@@ -797,21 +798,22 @@ class SessionSummary(Static, can_focus=True):
             content.append("      -", style=f"dim orange1{bg}")
 
         # Git diff stats (outstanding changes since last commit)
-        # ALIGNMENT: Use fixed widths - low/med: 4 chars "Δnn ", full: 15 chars "Δnn +nnnn -nnn"
+        # ALIGNMENT: Use fixed widths - low/med: 4 chars "Δnn ", full: 16 chars "Δnn +nnnn -nnnn"
+        # Large line counts are shortened: 173242 -> "173K", 1234567 -> "1.2M"
         if self.git_diff_stats:
             files, ins, dels = self.git_diff_stats
             if self.summary_detail == "full":
                 # Full: show files and lines with fixed widths
                 content.append(f" Δ{files:>2}", style=f"bold magenta{bg}")
-                content.append(f" +{ins:>4}", style=f"bold green{bg}")
-                content.append(f" -{dels:>3}", style=f"bold red{bg}")
+                content.append(f" +{format_line_count(ins):>4}", style=f"bold green{bg}")
+                content.append(f" -{format_line_count(dels):>4}", style=f"bold red{bg}")
             else:
                 # Compact: just files changed (fixed 4 char width)
                 content.append(f" Δ{files:>2}", style=f"bold magenta{bg}" if files > 0 else f"dim{bg}")
         else:
             # Placeholder matching width for alignment
             if self.summary_detail == "full":
-                content.append("  Δ-  +   -  -", style=f"dim{bg}")
+                content.append("  Δ-  +   -  -  ", style=f"dim{bg}")
             else:
                 content.append("  Δ-", style=f"dim{bg}")
 

--- a/src/overcode/tui_helpers.py
+++ b/src/overcode/tui_helpers.py
@@ -96,6 +96,24 @@ def format_tokens(tokens: int) -> str:
         return str(tokens)
 
 
+def format_line_count(count: int) -> str:
+    """Format line count (insertions/deletions) to human readable (K/M).
+
+    Args:
+        count: Number of lines
+
+    Returns:
+        Formatted string like "173K", "1.2M", or "500" for small counts.
+        Uses no decimal for K values to keep display compact.
+    """
+    if count >= 1_000_000:
+        return f"{count / 1_000_000:.1f}M"
+    elif count >= 1_000:
+        return f"{count // 1_000}K"
+    else:
+        return str(count)
+
+
 def calculate_uptime(start_time: str, now: Optional[datetime] = None) -> str:
     """Calculate uptime from ISO format start_time.
 


### PR DESCRIPTION
## Summary
- Add `format_line_count()` helper to shorten large numbers (e.g., 173242 -> "173K", 1234567 -> "1.2M")
- Use it for git insertions/deletions display in summary lines
- Add comprehensive tests for summary line alignment to prevent future regressions

## Test plan
- [x] Run `pytest tests/unit/test_tui.py::TestFormatLineCount` - all pass
- [x] Run `pytest tests/unit/test_tui.py::TestSummaryLineAlignment` - all pass
- [x] Run full test suite `pytest tests/unit/test_tui.py` - 132 passed, 8 skipped

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)