### PR TITLE
Add DO_NOTHING standing order as default, rename DEFAULT to STANDARD

### DIFF
--- a/src/overcode/cli.py
+++ b/src/overcode/cli.py
@@ -264,7 +264,7 @@ def instruct(
     ] = None,
     instructions: Annotated[
         Optional[List[str]],
-        typer.Argument(help="Instructions or preset name (e.g., DEFAULT, CODING)"),
+        typer.Argument(help="Instructions or preset name (e.g., DO_NOTHING, STANDARD, CODING)"),
     ] = None,
     clear: Annotated[
         bool, typer.Option("--clear", "-c", help="Clear standing instructions")
@@ -276,7 +276,7 @@ def instruct(
 ):
     """Set standing instructions for an agent.
 
-    Use a preset name (DEFAULT, CODING, TESTING, etc.) or provide custom instructions.
+    Use a preset name (DO_NOTHING, STANDARD, CODING, etc.) or provide custom instructions.
     Use --list to see all available presets.
     """
     from .session_manager import SessionManager
@@ -285,7 +285,7 @@ def instruct(
     if list_presets:
         presets_dict = load_presets()
         rprint("\n[bold]Standing Instruction Presets:[/bold]\n")
-        for preset_name in sorted(presets_dict.keys(), key=lambda x: (x != "DEFAULT", x)):
+        for preset_name in sorted(presets_dict.keys(), key=lambda x: (x != "DO_NOTHING", x)):
             preset = presets_dict[preset_name]
             rprint(f"  [cyan]{preset_name:12}[/cyan] {preset.description}")
         rprint("\n[dim]Usage: overcode instruct <agent> <PRESET>[/dim]")

--- a/src/overcode/standing_instructions.py
+++ b/src/overcode/standing_instructions.py
@@ -24,8 +24,17 @@ class InstructionPreset:
 
 # Default presets - used to generate initial presets.json
 DEFAULT_PRESETS: Dict[str, InstructionPreset] = {
-    "DEFAULT": InstructionPreset(
-        name="DEFAULT",
+    "DO_NOTHING": InstructionPreset(
+        name="DO_NOTHING",
+        description="Supervisor ignores this agent (default)",
+        instructions=(
+            "Do not interact with this agent at all. Do not approve or reject any prompts. "
+            "Do not send any input. Leave the agent completely alone and let it wait for "
+            "the human user. This agent is not under supervisor control."
+        ),
+    ),
+    "STANDARD": InstructionPreset(
+        name="STANDARD",
         description="General-purpose safe automation",
         instructions=(
             "Approve safe operations within the working directory: file reads/writes/edits, "
@@ -208,11 +217,11 @@ def get_preset_names() -> List[str]:
         List of preset names
     """
     presets = load_presets()
-    # Return in a consistent order (DEFAULT first, then alphabetical)
+    # Return in a consistent order (DO_NOTHING first, then alphabetical)
     names = list(presets.keys())
-    if "DEFAULT" in names:
-        names.remove("DEFAULT")
-        names = ["DEFAULT"] + sorted(names)
+    if "DO_NOTHING" in names:
+        names.remove("DO_NOTHING")
+        names = ["DO_NOTHING"] + sorted(names)
     else:
         names = sorted(names)
     return names

--- a/tests/unit/test_standing_instructions.py
+++ b/tests/unit/test_standing_instructions.py
@@ -40,7 +40,8 @@ class TestDefaultPresets:
     """Tests for default preset definitions."""
 
     def test_default_presets_exist(self):
-        assert "DEFAULT" in DEFAULT_PRESETS
+        assert "DO_NOTHING" in DEFAULT_PRESETS
+        assert "STANDARD" in DEFAULT_PRESETS
         assert "PERMISSIVE" in DEFAULT_PRESETS
         assert "CAUTIOUS" in DEFAULT_PRESETS
         assert "RESEARCH" in DEFAULT_PRESETS
@@ -52,7 +53,7 @@ class TestDefaultPresets:
         assert "MINIMAL" in DEFAULT_PRESETS
 
     def test_default_presets_count(self):
-        assert len(DEFAULT_PRESETS) == 10
+        assert len(DEFAULT_PRESETS) == 11
 
     def test_all_presets_have_required_fields(self):
         for name, preset in DEFAULT_PRESETS.items():
@@ -67,9 +68,9 @@ class TestResolveInstructions:
     """Tests for resolve_instructions function."""
 
     def test_resolve_known_preset(self):
-        instructions, preset_name = resolve_instructions("DEFAULT")
-        assert preset_name == "DEFAULT"
-        assert instructions == DEFAULT_PRESETS["DEFAULT"].instructions
+        instructions, preset_name = resolve_instructions("STANDARD")
+        assert preset_name == "STANDARD"
+        assert instructions == DEFAULT_PRESETS["STANDARD"].instructions
 
     def test_resolve_preset_case_insensitive(self):
         instructions, preset_name = resolve_instructions("coding")
@@ -96,14 +97,14 @@ class TestGetPreset:
     """Tests for get_preset function."""
 
     def test_get_existing_preset(self):
-        preset = get_preset("DEFAULT")
+        preset = get_preset("DO_NOTHING")
         assert preset is not None
-        assert preset.name == "DEFAULT"
+        assert preset.name == "DO_NOTHING"
 
     def test_get_preset_case_insensitive(self):
-        preset = get_preset("default")
+        preset = get_preset("do_nothing")
         assert preset is not None
-        assert preset.name == "DEFAULT"
+        assert preset.name == "DO_NOTHING"
 
     def test_get_nonexistent_preset(self):
         preset = get_preset("NONEXISTENT")
@@ -113,9 +114,9 @@ class TestGetPreset:
 class TestGetPresetNames:
     """Tests for get_preset_names function."""
 
-    def test_default_first(self):
+    def test_do_nothing_first(self):
         names = get_preset_names()
-        assert names[0] == "DEFAULT"
+        assert names[0] == "DO_NOTHING"
 
     def test_rest_alphabetical(self):
         names = get_preset_names()
@@ -146,8 +147,8 @@ class TestLoadAndSavePresets:
             presets = load_presets()
 
         assert temp_presets_path.exists()
-        assert "DEFAULT" in presets
-        assert len(presets) == 10
+        assert "DO_NOTHING" in presets
+        assert len(presets) == 11
 
     def test_load_reads_existing_file(self, temp_presets_path):
         """Loading reads from existing file."""
@@ -274,28 +275,33 @@ class TestResetPresets:
             # Verify custom preset exists
             presets = load_presets()
             assert "CUSTOM" in presets
-            assert "DEFAULT" not in presets
+            assert "DO_NOTHING" not in presets
 
             # Reset
             reset_presets()
 
             # Verify defaults restored
             presets = load_presets()
-            assert "DEFAULT" in presets
+            assert "DO_NOTHING" in presets
             assert "CUSTOM" not in presets
-            assert len(presets) == 10
+            assert len(presets) == 11
 
 
 class TestPresetInstructionsContent:
     """Tests to verify preset instruction content quality."""
 
-    def test_default_mentions_approve_and_reject(self):
-        preset = DEFAULT_PRESETS["DEFAULT"]
+    def test_do_nothing_tells_supervisor_to_ignore(self):
+        preset = DEFAULT_PRESETS["DO_NOTHING"]
+        assert "not" in preset.instructions.lower()
+        assert "alone" in preset.instructions.lower() or "ignore" in preset.instructions.lower()
+
+    def test_standard_mentions_approve_and_reject(self):
+        preset = DEFAULT_PRESETS["STANDARD"]
         assert "approve" in preset.instructions.lower()
         assert "reject" in preset.instructions.lower()
 
     def test_permissive_is_less_restrictive(self):
-        default = DEFAULT_PRESETS["DEFAULT"]
+        standard = DEFAULT_PRESETS["STANDARD"]
         permissive = DEFAULT_PRESETS["PERMISSIVE"]
         # PERMISSIVE should mention trusting the agent
         assert "trust" in permissive.instructions.lower()


### PR DESCRIPTION
## Summary
- Adds `DO_NOTHING` preset that tells supervisor to leave the agent completely alone
- Makes `DO_NOTHING` the default standing order (listed first in presets)
- Renames existing `DEFAULT` preset to `STANDARD` to avoid confusion

## Changes
- `standing_instructions.py`: Added DO_NOTHING preset, renamed DEFAULT to STANDARD, updated ordering logic
- `cli.py`: Updated help text to reference new preset names
- `test_standing_instructions.py`: Updated tests for new preset structure (now 11 presets total)

## DO_NOTHING preset behavior
The supervisor will:
- Not approve or reject any prompts
- Not send any input to the agent
- Leave the agent to wait for human user input

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)