### PR TITLE
Fix monitor daemon to always use 10s polling interval

### DIFF
--- a/src/overcode/monitor_daemon.py
+++ b/src/overcode/monitor_daemon.py
@@ -426,13 +426,13 @@ class MonitorDaemon:
         return sorted_times[n // 2]
 
     def calculate_interval(self, sessions: list, all_waiting_user: bool) -> int:
-        """Calculate appropriate loop interval."""
-        if not sessions:
-            return INTERVAL_IDLE
+        """Calculate appropriate loop interval.
 
-        if all_waiting_user:
-            return INTERVAL_SLOW
-
+        The monitor daemon always uses a fixed 10s interval to maintain
+        high-resolution monitoring data. Variable frequency logic is only
+        used by the supervisor daemon.
+        """
+        # Always use fast interval for consistent monitoring resolution
         return INTERVAL_FAST
 
     def _interruptible_sleep(self, total_seconds: int) -> None:


### PR DESCRIPTION
## Summary
- Monitor daemon now always uses 10s interval for consistent monitoring resolution
- Variable frequency logic (slow/idle intervals) removed from monitor daemon
- This preserves high-resolution data for timeline and metrics

## Problem
The monitor daemon was dropping to 5-minute or 1-hour intervals when agents were idle, causing loss of granularity in monitoring data.

## Solution
`calculate_interval()` now always returns `INTERVAL_FAST` (10s). Variable frequency logic should only apply to the supervisor daemon, not the monitor.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)