### PR TITLE
Make preview pane use available height instead of fixed 30 lines

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -953,8 +953,11 @@ class PreviewPane(Static):
         if not self.content_lines:
             content.append("(no output)", style="dim italic")
         else:
-            # Show last 30 lines of output - plain text, no decoration
-            for line in self.content_lines[-30:]:
+            # Calculate available lines based on widget height
+            # Reserve 2 lines for header and some padding
+            available_lines = max(10, self.size.height - 2) if self.size.height > 0 else 30
+            # Show last N lines of output - plain text, no decoration
+            for line in self.content_lines[-available_lines:]:
                 # Truncate long lines
                 display_line = line[:200] if len(line) > 200 else line
                 content.append(display_line + "\n")


### PR DESCRIPTION
## Summary
- Preview pane now dynamically calculates line count based on available height
- Removes hardcoded 30-line limit that was wasting vertical space
- Minimum of 10 lines, falls back to 30 if height unavailable

## Problem
Preview mode was only showing ~30 lines even when 60+ lines were available on the terminal.

## Solution
Use `self.size.height` to calculate available lines dynamically, reserving 2 lines for header.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)