### PR TITLE
Show install instructions when presence deps not installed

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -47,7 +47,7 @@ from .web_server import (
 )
 from .config import get_default_standing_instructions
 from .status_history import read_agent_status_history
-from .presence_logger import read_presence_history
+from .presence_logger import read_presence_history, MACOS_APIS_AVAILABLE
 from .launcher import ClaudeLauncher
 from .tui_helpers import (
     format_interval,
@@ -352,6 +352,10 @@ class StatusTimeline(Static):
                     content.append(char, style=color)
                 else:
                     content.append("─", style="dim")
+        elif not MACOS_APIS_AVAILABLE:
+            # Show install instructions when presence deps not installed
+            msg = "not installed - pip install overcode[presence]"
+            content.append(msg[:width], style="dim italic")
         else:
             content.append("─" * width, style="dim")
         content.append("\n")


### PR DESCRIPTION
## Summary
- When pyobjc dependencies aren't installed, the User timeline now shows helpful install instructions
- Message: `not installed - pip install overcode[presence]` in dim italic text
- Guides users to install the optional presence tracking dependencies instead of showing confusing empty dashes

## Test plan
- [ ] Uninstall pyobjc deps and verify message appears on User line
- [ ] Install deps and verify normal timeline appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)