### PR TITLE
Fix user monitoring timeline message to indicate macOS-only feature

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -355,8 +355,8 @@ class StatusTimeline(Static):
                 else:
                     content.append("─", style="dim")
         elif not MACOS_APIS_AVAILABLE:
-            # Show install instructions when presence deps not installed
-            msg = "not installed - pip install overcode[presence]"
+            # Show install instructions when presence deps not installed (macOS only)
+            msg = "macOS only - pip install overcode[presence]"
             content.append(msg[:width], style="dim italic")
         else:
             content.append("─" * width, style="dim")


### PR DESCRIPTION
## Summary
- Update the "not installed" message in the user monitoring timeline to indicate this feature only works on macOS
- The presence detection feature uses macOS-specific APIs (Quartz, ApplicationServices)
- Message changed from "not installed - pip install overcode[presence]" to "macOS only - pip install overcode[presence]"

## Test plan
- [ ] Verify the message displays correctly on non-macOS systems or when presence dependencies are not installed
- [ ] Check that the message fits within the timeline display width

Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)