### PR TITLE
Fix context indicator c@NN% alignment in TUI edge cases

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -844,15 +844,18 @@ class SessionSummary(Static, can_focus=True):
                 content.append(f" {pct:>3.0f}%", style=f"bold green{bg}" if pct >= 50 else f"bold red{bg}")
 
         # Always show: token usage (from Claude Code)
+        # ALIGNMENT: context indicator is always 7 chars " c@NNN%" (or placeholder)
         if self.claude_stats is not None:
             content.append(f" Σ{format_tokens(self.claude_stats.total_tokens):>6}", style=f"bold orange1{bg}")
             # Show current context window usage as percentage (assuming 200K max)
             if self.claude_stats.current_context_tokens > 0:
                 max_context = 200_000  # Claude models have 200K context window
                 ctx_pct = min(100, self.claude_stats.current_context_tokens / max_context * 100)
-                content.append(f" c@{ctx_pct:.0f}%", style=f"bold orange1{bg}")
+                content.append(f" c@{ctx_pct:>3.0f}%", style=f"bold orange1{bg}")
+            else:
+                content.append(" c@  -%", style=f"dim orange1{bg}")
         else:
-            content.append("      -", style=f"dim orange1{bg}")
+            content.append("      - c@  -%", style=f"dim orange1{bg}")
 
         # Git diff stats (outstanding changes since last commit)
         # ALIGNMENT: Use fixed widths - low/med: 4 chars "Δnn ", full: 16 chars "Δnn +nnnn -nnnn"


### PR DESCRIPTION
## Summary
- Fixed edge case where the context indicator `c@NN%` would disappear when `claude_stats` exists but `current_context_tokens` is 0
- Added placeholder rendering to maintain consistent column alignment in all cases
- Updated the format string to use fixed-width formatting (`>3.0f`) for consistent alignment

## Test plan
- [ ] Start overcode with a fresh session where no context tokens have been used yet
- [ ] Verify the context indicator shows a placeholder like `c@  -%` instead of being missing
- [ ] Confirm alignment is consistent across multiple sessions in different states

Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)