### PR TITLE
Fix session isolation for agent history (fixes #19)

### DIFF
--- a/src/overcode/monitor_daemon.py
+++ b/src/overcode/monitor_daemon.py
@@ -614,8 +614,8 @@ class MonitorDaemon:
                     session_state.current_activity = activity
                     session_states.append(session_state)
 
-                    # Log status history
-                    log_agent_status(session.name, status, activity)
+                    # Log status history to session-specific file
+                    log_agent_status(session.name, status, activity, history_file=self.history_path)
 
                     # Track if any session is not waiting for user
                     if status != "waiting_user":

--- a/src/overcode/web_server.py
+++ b/src/overcode/web_server.py
@@ -338,6 +338,9 @@ def toggle_web_server(session: str, port: int = 8080) -> Tuple[bool, str]:
 class AnalyticsHandler(BaseHTTPRequestHandler):
     """HTTP request handler for analytics dashboard."""
 
+    # Set by run_analytics_server before starting
+    tmux_session: str = "agents"
+
     def do_GET(self) -> None:
         """Handle GET requests."""
         parsed = urlparse(self.path)
@@ -355,9 +358,9 @@ class AnalyticsHandler(BaseHTTPRequestHandler):
         elif path == "/api/analytics/sessions":
             self._serve_json(get_analytics_sessions(start, end))
         elif path == "/api/analytics/timeline":
-            self._serve_json(get_analytics_timeline(start, end))
+            self._serve_json(get_analytics_timeline(self.tmux_session, start, end))
         elif path == "/api/analytics/stats":
-            self._serve_json(get_analytics_stats(start, end))
+            self._serve_json(get_analytics_stats(self.tmux_session, start, end))
         elif path == "/api/analytics/daily":
             self._serve_json(get_analytics_daily(start, end))
         elif path == "/api/analytics/presets":
@@ -434,13 +437,18 @@ class AnalyticsHandler(BaseHTTPRequestHandler):
 def run_analytics_server(
     host: str = "127.0.0.1",
     port: int = 8080,
+    tmux_session: str = "agents",
 ) -> None:
     """Run the analytics web dashboard server.
 
     Args:
         host: Host to bind to (default: 127.0.0.1 for local only)
         port: Port to listen on (default: 8080)
+        tmux_session: tmux session name for session-specific data
     """
+    # Set the tmux session on the handler class
+    AnalyticsHandler.tmux_session = tmux_session
+
     server_address = (host, port)
 
     try:

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -9,6 +9,10 @@ import pytest
 from overcode.web_api import _calculate_presence_efficiency
 
 
+# Test session name for all tests
+TEST_SESSION = "test-session"
+
+
 class TestCalculatePresenceEfficiency:
     """Tests for presence efficiency calculation."""
 
@@ -24,7 +28,7 @@ class TestCalculatePresenceEfficiency:
             ]
             mock_presence.return_value = []
 
-            result = _calculate_presence_efficiency(start, end)
+            result = _calculate_presence_efficiency(TEST_SESSION, start, end)
 
             assert result['has_data'] is False
             assert result['present_efficiency'] == 0.0
@@ -40,7 +44,7 @@ class TestCalculatePresenceEfficiency:
             mock_agent.return_value = []
             mock_presence.return_value = []
 
-            result = _calculate_presence_efficiency(start, end)
+            result = _calculate_presence_efficiency(TEST_SESSION, start, end)
 
             assert result['has_data'] is False
             assert result['present_efficiency'] == 0.0
@@ -64,7 +68,7 @@ class TestCalculatePresenceEfficiency:
                 (start, 3),
             ]
 
-            result = _calculate_presence_efficiency(start, end, sample_interval_seconds=60)
+            result = _calculate_presence_efficiency(TEST_SESSION, start, end, sample_interval_seconds=60)
 
             assert result['has_data'] is True
             assert result['present_efficiency'] == 100.0
@@ -88,7 +92,7 @@ class TestCalculatePresenceEfficiency:
                 (start, 1),
             ]
 
-            result = _calculate_presence_efficiency(start, end, sample_interval_seconds=60)
+            result = _calculate_presence_efficiency(TEST_SESSION, start, end, sample_interval_seconds=60)
 
             assert result['has_data'] is True
             assert result['present_efficiency'] == 0.0
@@ -114,7 +118,7 @@ class TestCalculatePresenceEfficiency:
                 (midpoint, 1),  # Then locked
             ]
 
-            result = _calculate_presence_efficiency(start, end, sample_interval_seconds=60)
+            result = _calculate_presence_efficiency(TEST_SESSION, start, end, sample_interval_seconds=60)
 
             assert result['has_data'] is True
             # Both should be 100% since agent was running throughout
@@ -140,7 +144,7 @@ class TestCalculatePresenceEfficiency:
                 (start, 3),
             ]
 
-            result = _calculate_presence_efficiency(start, end, sample_interval_seconds=60)
+            result = _calculate_presence_efficiency(TEST_SESSION, start, end, sample_interval_seconds=60)
 
             assert result['has_data'] is True
             # 1 of 2 agents running = 50%
@@ -162,7 +166,7 @@ class TestCalculatePresenceEfficiency:
                 (start, 2),
             ]
 
-            result = _calculate_presence_efficiency(start, end, sample_interval_seconds=60)
+            result = _calculate_presence_efficiency(TEST_SESSION, start, end, sample_interval_seconds=60)
 
             assert result['has_data'] is True
             assert result['present_efficiency'] == 0.0
@@ -176,7 +180,7 @@ class TestCalculatePresenceEfficiency:
             mock_agent.return_value = []
             mock_presence.return_value = []
 
-            result = _calculate_presence_efficiency()
+            result = _calculate_presence_efficiency(TEST_SESSION)
 
             # Should not raise, just return empty data
             assert result['has_data'] is False
@@ -214,7 +218,7 @@ class TestGetAnalyticsStatsIncludesPresenceEfficiency:
                 'has_data': True,
             }
 
-            result = get_analytics_stats()
+            result = get_analytics_stats(TEST_SESSION)
 
             assert 'presence_efficiency' in result
             assert result['presence_efficiency']['present_efficiency'] == 75.0


### PR DESCRIPTION
## Summary

- Fixed erratic timeline rendering caused by multiple monitor daemons writing to a single global history file
- Each session now has its own isolated agent status history file at `~/.overcode/sessions/<session>/agent_status_history.csv`
- Web dashboard, analytics, and TUI all now read from session-specific history files

## Root Cause

When running multiple monitor daemons (e.g., for `agents`, `test-pilot`, `test-agents-72087` sessions), they were all:
1. Writing to the same global `~/.overcode/agent_status_history.csv` file
2. Reading from that global file without session filtering

This caused timeline data from different sessions to be mixed together, resulting in the "stochastic" rendering behavior where agent status would jump around erratically on mouse move.

## Changes

- `monitor_daemon.py`: Now passes `self.history_path` (session-specific) to `log_agent_status()` instead of using the global default
- `web_api.py`: `get_timeline_data()`, `get_analytics_timeline()`, `get_analytics_stats()`, and `_calculate_presence_efficiency()` now use session-specific history paths
- `web_server.py`: Analytics handler now tracks `tmux_session` like the main dashboard handler
- `tui.py`: `StatusTimeline` widget now accepts `tmux_session` and reads from the correct session-specific file
- `tests/unit/test_web_api.py`: Updated tests for new function signatures

## Test plan

- [x] Unit tests pass (22 passed in test_status_history.py and test_web_api.py)
- [x] Full test suite passes (572 passed, 1 unrelated pre-existing failure)
- [ ] Manual testing with multiple monitor daemons to verify isolation
- [ ] Verify timeline no longer shows erratic behavior on mouse move

🤖 Generated with [Claude Code](https://claude.com/claude-code)