### PR TITLE
Fix preview pane not updating when focus moves to other widgets

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -2244,9 +2244,9 @@ class SupervisorTUI(App):
         """Update preview pane with focused session's content."""
         try:
             preview = self.query_one("#preview-pane", PreviewPane)
-            focused = self.focused
-            if isinstance(focused, SessionSummary):
-                preview.update_from_widget(focused)
+            widgets = self._get_widgets_in_session_order()
+            if widgets and 0 <= self.focused_session_index < len(widgets):
+                preview.update_from_widget(widgets[self.focused_session_index])
         except NoMatches:
             pass
 


### PR DESCRIPTION
## Summary
- Fixed `_update_preview()` to use `focused_session_index` instead of `self.focused`
- Preview pane now continues updating even when focus is on CommandBar or other widgets
- The underlying SessionSummary data was always updating; only the preview read was broken

## Root Cause
The method checked `isinstance(self.focused, SessionSummary)` which failed when focus moved to CommandBar (e.g., when typing instructions). Changed to look up the widget via the already-tracked `focused_session_index`.

## Test plan
- [x] Existing TUI tests pass (132 passed)
- [ ] Manual test: Open TUI in list+preview mode, focus command bar, verify preview continues updating

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)