### PR TITLE
Make summarizer output more terse and action-focused

### DIFF
--- a/src/overcode/summarizer_client.py
+++ b/src/overcode/summarizer_client.py
@@ -17,27 +17,28 @@ MODEL = "gpt-4o-mini"
 API_URL = "https://api.openai.com/v1/chat/completions"
 
 # Anti-oscillation prompt template
-SUMMARIZE_PROMPT = """You are summarizing a Claude Code agent's terminal output.
+SUMMARIZE_PROMPT = """Summarize a Claude Code agent's terminal output.
 
-## Current Terminal Content (last {lines} lines):
+## Terminal Content (last {lines} lines):
 {pane_content}
 
-## Current Status: {status}
+## Status: {status}
 
 ## Previous Summary:
 {previous_summary}
 
 ## Instructions:
-1. Summarize what the agent has been doing in 1-2 sentences
-2. If not running, explain the halt state (waiting for user input, permission needed, etc.)
-3. IMPORTANT: Only provide a new summary if there's meaningful new information.
-   If the situation is essentially the same as the previous summary, respond with exactly:
-   UNCHANGED
+Write a terse 1-sentence summary. Be direct and action-focused.
 
-Keep summaries concise (under 80 words). Focus on:
-- What task/feature is being worked on
-- Current action (reading files, writing code, running tests, etc.)
-- If halted: why and what's needed to continue"""
+Style guide:
+- NO "The agent is/has..." or "Claude is..." phrasing
+- Start with lowercase verb or noun: "implementing...", "reading...", "tests passing"
+- Use shorthand: "fixed bug, running tests" not "The agent has fixed the bug and is now running tests"
+- Examples: "adding auth middleware, 3 files modified" / "waiting for user approval on delete operation" / "tests green, pushing to remote"
+
+If nothing meaningful changed from previous summary, respond exactly: UNCHANGED
+
+Max 60 chars when possible. Focus on: current action, what's being built/fixed, blockers if halted."""
 
 
 class SummarizerClient:


### PR DESCRIPTION
## Summary
- Updates `SUMMARIZE_PROMPT` to produce shorter, snappier summaries
- Eliminates verbose patterns like "The agent has..." or "Claude is..."
- Encourages lowercase verb/noun starts: "implementing...", "reading...", "tests passing"
- Targets ~60 chars instead of 80 words

## Before/After Examples
| Before | After |
|--------|-------|
| "The agent has implemented the subagent token usage feature and has now verified it working" | "implemented subagent token stats, verified working" |
| "The Claude Code agent is currently reading configuration files" | "reading config files" |
| "The agent is waiting for user input to proceed" | "waiting for user approval" |

## Test plan
- [ ] Manual test: Run overcode with active agents, verify summaries are shorter and don't start with "The agent..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)