### PR TITLE
Refactor tmux operations to use libtmux library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "rich>=13.0.0",
     "typer>=0.9.0",
     "pyyaml>=6.0",
+    "libtmux>=0.37.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- Replace subprocess-based tmux operations with the libtmux library for more reliable and maintainable tmux interaction
- Add libtmux>=0.37.0 as a core dependency
- Refactor RealTmux and TmuxManager to use libtmux API

## Benefits
- Cleaner, more Pythonic API instead of raw subprocess calls
- Better error handling through libtmux exceptions
- Lazy server connection initialization
- Consistent behavior across all tmux operations

## Test plan
- [x] All existing tests pass (548 passed, 22 skipped)
- [x] Test isolation via OVERCODE_TMUX_SOCKET env var works correctly
- [x] Send keys with separate Enter delay for Claude Code preserved

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)