### PR TITLE
Create directory when it doesn't exist in new agent dialog

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -1259,9 +1259,13 @@ class CommandBar(Static):
         if directory:
             dir_path = Path(directory).expanduser().resolve()
             if not dir_path.exists():
-                # Try to create it or warn
-                self.app.notify(f"Directory does not exist: {dir_path}", severity="warning")
-                return
+                # Create the directory
+                try:
+                    dir_path.mkdir(parents=True, exist_ok=True)
+                    self.app.notify(f"Created directory: {dir_path}", severity="information")
+                except OSError as e:
+                    self.app.notify(f"Failed to create directory: {e}", severity="error")
+                    return
             if not dir_path.is_dir():
                 self.app.notify(f"Not a directory: {dir_path}", severity="error")
                 return


### PR DESCRIPTION
## Summary
- When creating a new agent, if the specified directory doesn't exist, create it automatically
- Uses `mkdir(parents=True)` to support nested paths
- Shows confirmation notification when directory is created
- Shows error if directory creation fails

Fixes #71

## Test plan
- [ ] Create new agent with non-existent directory path
- [ ] Verify directory is created and agent launches in it
- [ ] Verify error handling for invalid paths (e.g., permission denied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)