### PR TITLE
Fix time-in-state not resetting immediately on status change

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -665,6 +665,9 @@ class SessionSummary(Static, can_focus=True):
         self.git_diff_stats: Optional[tuple] = None  # (files, insertions, deletions)
         # Track if this is a stalled agent that hasn't been visited yet
         self.is_unvisited_stalled: bool = False
+        # Track when status last changed (for immediate time-in-state updates)
+        self._status_changed_at: Optional[datetime] = None
+        self._last_known_status: str = self.detected_status
         # Start with expanded class since expanded=True by default
         self.add_class("expanded")
 
@@ -764,10 +767,14 @@ class SessionSummary(Static, can_focus=True):
         # NOTE: Time tracking removed - Monitor Daemon is the single source of truth
         # The session.stats values are read from what Monitor Daemon has persisted
         # If session is asleep, keep the asleep status instead of the detected status
-        if self.session.is_asleep:
-            self.detected_status = "asleep"
-        else:
-            self.detected_status = status
+        new_status = "asleep" if self.session.is_asleep else status
+
+        # Track status changes for immediate time-in-state reset (#73)
+        if new_status != self._last_known_status:
+            self._status_changed_at = datetime.now()
+            self._last_known_status = new_status
+
+        self.detected_status = new_status
 
         # Use pre-fetched claude stats (no file I/O on main thread)
         if claude_stats is not None:
@@ -836,13 +843,21 @@ class SessionSummary(Static, can_focus=True):
             content.append("  ", style=f"dim{bg}")  # Maintain alignment
 
         # Time in current state (directly after status light)
+        # Use locally tracked change time if more recent than daemon's state_since (#73)
+        state_start = None
+        if self._status_changed_at:
+            state_start = self._status_changed_at
         if stats.state_since:
             try:
-                state_start = datetime.fromisoformat(stats.state_since)
-                elapsed = (datetime.now() - state_start).total_seconds()
-                content.append(f"{format_duration(elapsed):>5} ", style=status_color)
+                daemon_state_start = datetime.fromisoformat(stats.state_since)
+                # Use whichever is more recent (our local detection or daemon's record)
+                if state_start is None or daemon_state_start > state_start:
+                    state_start = daemon_state_start
             except (ValueError, TypeError):
-                content.append("    - ", style=f"dim{bg}")
+                pass
+        if state_start:
+            elapsed = (datetime.now() - state_start).total_seconds()
+            content.append(f"{format_duration(elapsed):>5} ", style=status_color)
         else:
             content.append("    - ", style=f"dim{bg}")
 


### PR DESCRIPTION
## Summary
When an agent changed state (e.g., red to green), the status color updated immediately but the "time in state" number continued showing the old duration until the daemon's next poll cycle. This was confusing as users expected the time to reset immediately.

## Solution
- Track status changes locally in the TUI widget
- Use the more recent of local detection time or daemon's state_since
- Provides immediate feedback while maintaining persistence across restarts

Fixes #73

## Test plan
- [ ] Run overcode with an agent in red state
- [ ] Send input to make it go green
- [ ] Verify both color AND time reset immediately
- [ ] Verify time continues to count up correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)