### PR TITLE
Add human annotation field and summary content modes

### DIFF
--- a/src/overcode/session_manager.py
+++ b/src/overcode/session_manager.py
@@ -95,6 +95,9 @@ class Session:
     # Default 1000, higher = more important
     agent_value: int = 1000
 
+    # Human annotation - user's notes about this agent (#74)
+    human_annotation: str = ""
+
     def to_dict(self) -> dict:
         data = asdict(self)
         # Convert stats to dict
@@ -620,3 +623,7 @@ class SessionManager:
             value: Priority value (default 1000, higher = more important)
         """
         self.update_session(session_id, agent_value=value)
+
+    def set_human_annotation(self, session_id: str, annotation: str):
+        """Set human annotation for a session (#74)."""
+        self.update_session(session_id, human_annotation=annotation)

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -214,6 +214,31 @@ class TestSessionManagerUpdates:
         updated = manager.get_session(session.id)
         assert updated.agent_value == 500
 
+    def test_set_human_annotation(self, tmp_path):
+        """Can set human annotation (#74)"""
+        manager = SessionManager(state_dir=tmp_path, skip_git_detection=True)
+        session = manager.create_session(
+            name="test",
+            tmux_session="agents",
+            tmux_window=1,
+            command=["claude"]
+        )
+
+        # Initially empty
+        assert session.human_annotation == ""
+
+        # Set annotation
+        manager.set_human_annotation(session.id, "working on auth refactor")
+
+        updated = manager.get_session(session.id)
+        assert updated.human_annotation == "working on auth refactor"
+
+        # Clear annotation
+        manager.set_human_annotation(session.id, "")
+
+        cleared = manager.get_session(session.id)
+        assert cleared.human_annotation == ""
+
 
 class TestSessionStats:
     """Test session statistics tracking"""


### PR DESCRIPTION
## Summary
- Adds `human_annotation` field to Session for user notes about agents (#74)
- Adds `l` keybinding to cycle through summary content modes: AI short, AI long, orders, annotation
- Adds `I` keybinding to edit human annotation for focused agent via command bar
- Persists annotations in session config file

## Test plan
- [x] Unit test for `set_human_annotation` method added
- [ ] Manual test: Press `l` to cycle through content modes and verify display changes
- [ ] Manual test: Press `I` to edit annotation, type text, press Enter to save
- [ ] Verify annotation persists after TUI restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)