### PR TITLE
Fix timeline width calculation to account for CSS padding

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -301,8 +301,12 @@ class StatusTimeline(Static):
         try:
             # Try to get terminal size directly - most reliable
             term_width = shutil.get_terminal_size().columns
-            # Subtract dynamic label width (+ 3 for "  " prefix and " " suffix) and percentage display (+ 6)
-            available = term_width - self.label_width - 3 - 6
+            # Subtract:
+            #   - label_width (agent name)
+            #   - 3 for "  " prefix and " " suffix around label
+            #   - 5 for percentage display " XXX%"
+            #   - 2 for CSS padding (padding: 0 1 = 1 char each side)
+            available = term_width - self.label_width - 3 - 5 - 2
             return max(self.MIN_TIMELINE, min(available, 200))
         except (OSError, ValueError):
             # No terminal available or invalid size


### PR DESCRIPTION
## Summary
The timeline percentage display was overspilling because the width calculation didn't account for the CSS padding on the `#timeline` widget.

## Root Cause
The `#timeline` CSS has `padding: 0 1` which adds 1 character on each side (2 total), but `timeline_width` wasn't subtracting this.

## Fix
Updated the calculation to subtract:
- `label_width` (agent name)
- 3 for `"  "` prefix and `" "` suffix around label  
- 5 for percentage display `" XXX%"`
- 2 for CSS padding (`padding: 0 1` = 1 char each side)

## Test plan
- [ ] Run `overcode monitor` with various terminal widths
- [ ] Verify percentages don't wrap to next line
- [ ] Verify timeline still uses available space efficiently

🤖 Generated with [Claude Code](https://claude.com/claude-code)