### PR TITLE
Display overcode version in TUI title bar

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -25,6 +25,7 @@ from textual.message import Message
 from rich.text import Text
 from rich.panel import Panel
 
+from . import __version__
 from .session_manager import SessionManager, Session
 from .launcher import ClaudeLauncher
 from .status_detector import StatusDetector
@@ -1842,7 +1843,7 @@ class SupervisorTUI(App):
 
     def on_mount(self) -> None:
         """Called when app starts"""
-        self.title = "Overcode Monitor"
+        self.title = f"Overcode v{__version__}"
         self._update_subtitle()
 
         # Auto-start Monitor Daemon if not running


### PR DESCRIPTION
## Summary
- Shows version from `__version__` in the TUI header
- Title now displays "Overcode v0.1.2" instead of "Overcode Monitor"

## Test plan
- [ ] Run `overcode` and verify version appears in title bar

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)