### PR TITLE
Reject agent values outside 0-9999 range in TUI

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -1421,6 +1421,9 @@ class CommandBar(Static):
             return
         try:
             value = int(text.strip()) if text.strip() else 1000
+            if value < 0 or value > 9999:
+                self.app.notify("Value must be between 0 and 9999", severity="error")
+                return
             self.post_message(self.ValueUpdated(self.target_session, value))
         except ValueError:
             # Invalid input, notify user but don't crash


### PR DESCRIPTION
## Summary
- Adds validation to `_set_value()` to reject values <0 or >9999
- Shows user-friendly error notification when invalid value entered
- Prevents display overflow in the 4-character value field (⭐XXXX)

## Test plan
- [ ] Press `V` on an agent, enter `10000`, verify error notification appears
- [ ] Press `V`, enter `-1`, verify error notification appears
- [ ] Press `V`, enter `5000`, verify value is accepted

Fixes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)