### PR TITLE
Preserve summary content mode preference across TUI restarts

### DIFF
--- a/src/overcode/settings.py
+++ b/src/overcode/settings.py
@@ -383,6 +383,7 @@ class TUIPreferences:
     show_terminated: bool = False  # keep killed sessions visible in timeline
     hide_asleep: bool = False  # hide sleeping agents from display
     sort_mode: str = "alphabetical"  # alphabetical, by_status, by_value (#61)
+    summary_content_mode: str = "ai_short"  # ai_short, ai_long, orders, annotation (#98)
     # Session IDs of stalled agents that have been visited by the user
     visited_stalled_agents: Set[str] = field(default_factory=set)
 
@@ -411,6 +412,7 @@ class TUIPreferences:
                     show_terminated=data.get("show_terminated", False),
                     hide_asleep=data.get("hide_asleep", False),
                     sort_mode=data.get("sort_mode", "alphabetical"),
+                    summary_content_mode=data.get("summary_content_mode", "ai_short"),
                     visited_stalled_agents=set(data.get("visited_stalled_agents", [])),
                 )
         except (json.JSONDecodeError, IOError):
@@ -434,6 +436,7 @@ class TUIPreferences:
                     "show_terminated": self.show_terminated,
                     "hide_asleep": self.hide_asleep,
                     "sort_mode": self.sort_mode,
+                    "summary_content_mode": self.summary_content_mode,
                     "visited_stalled_agents": list(self.visited_stalled_agents),
                 }, f, indent=2)
         except (IOError, OSError):

--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -1822,6 +1822,8 @@ class SupervisorTUI(App):
         self.show_terminated = self._prefs.show_terminated
         # Initialize hide_asleep from preferences
         self.hide_asleep = self._prefs.hide_asleep
+        # Initialize summary_content_mode from preferences (#98)
+        self.summary_content_mode = self._prefs.summary_content_mode
         # Cache of terminated sessions (killed during this TUI session)
         self._terminated_sessions: dict[str, Session] = {}
 
@@ -2331,6 +2333,10 @@ class SupervisorTUI(App):
         current_idx = modes.index(self.summary_content_mode) if self.summary_content_mode in modes else 0
         new_idx = (current_idx + 1) % len(modes)
         self.summary_content_mode = modes[new_idx]
+
+        # Save preference (#98)
+        self._prefs.summary_content_mode = self.summary_content_mode
+        self._save_prefs()
 
         # Update all session widgets
         for widget in self.query(SessionSummary):


### PR DESCRIPTION
## Summary
- Adds `summary_content_mode` to `TUIPreferences` dataclass
- Loads preference on TUI startup
- Saves preference when `l` key cycles through modes
- The setting (ai_short, ai_long, orders, annotation) now persists between TUI sessions

## Test plan
- [ ] Start TUI, press `l` to cycle to "Standing Orders" mode
- [ ] Exit TUI with `q`
- [ ] Start TUI again, verify it still shows "Standing Orders" mode

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)