### PR TITLE
Fix empty string not clearing standing orders

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -1432,8 +1432,8 @@ class CommandBar(Static):
         self._update_target_label()
 
     def _set_standing_order(self, text: str) -> None:
-        """Set text as standing order."""
-        if not self.target_session or not text.strip():
+        """Set text as standing order (empty string clears orders)."""
+        if not self.target_session:
             return
         self.post_message(self.StandingOrderRequested(self.target_session, text.strip()))
 
@@ -2847,7 +2847,10 @@ class SupervisorTUI(App):
         session = self.session_manager.get_session_by_name(message.session_name)
         if session:
             self.session_manager.set_standing_instructions(session.id, message.text)
-            self.notify(f"Standing order set for {message.session_name}")
+            if message.text:
+                self.notify(f"Standing order set for {message.session_name}")
+            else:
+                self.notify(f"Standing order cleared for {message.session_name}")
             # Refresh session list to show updated standing order
             self.refresh_sessions()
         else:


### PR DESCRIPTION
## Summary
- Fixes bug where submitting empty text in standing orders mode did nothing
- The placeholder said "(or empty to clear)" but empty strings were ignored
- Now empty strings properly clear standing orders
- Notification shows "cleared" when orders are removed

## Test plan
- [ ] Press `o` on an agent with standing orders
- [ ] Clear the input field and press Enter
- [ ] Verify notification says "Standing order cleared for [name]"
- [ ] Verify the standing orders indicator shows cleared state

Fixes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)