### PR TITLE
Fix sort order not updating when pressing 'S'

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -2263,6 +2263,8 @@ class SupervisorTUI(App):
                         widget.add_class("terminated")
                     else:
                         widget.remove_class("terminated")
+            # Still reorder widgets to handle sort mode changes
+            self._reorder_session_widgets(container)
             return
 
         # Remove widgets for deleted sessions
@@ -2307,9 +2309,8 @@ class SupervisorTUI(App):
                 # The 250ms interval (update_all_statuses) will update status shortly
 
         # Reorder widgets to match display_sessions order
-        # New widgets are appended at end, but should appear in correct position
-        if sessions_added:
-            self._reorder_session_widgets(container)
+        # This must run after any structural changes AND after sort mode changes
+        self._reorder_session_widgets(container)
 
     def action_expand_all(self) -> None:
         """Expand all sessions"""


### PR DESCRIPTION
## Summary
- Fixed bug where pressing 'S' to cycle sort modes didn't visually reorder the session widgets
- The widgets stayed in their original DOM order despite `self.sessions` being sorted

## Root Cause
In `update_session_widgets()`:
- The early return path (lines 2255-2266) was taken when no sessions were added/removed
- `_reorder_session_widgets()` was only called when `sessions_added` was truthy
- So sort mode changes never triggered widget reordering

## Fix
Call `_reorder_session_widgets()` in both code paths:
1. Early return path (no structural changes, just data updates + sort order)
2. Normal path (after adding/removing widgets)

## Test plan
- [ ] Manual test: Launch TUI with multiple agents, press 'S' multiple times, verify order changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)