### PR TITLE
Change asleep timeline symbol from 'z' to grey hatching

### DIFF
--- a/src/overcode/status_constants.py
+++ b/src/overcode/status_constants.py
@@ -119,7 +119,7 @@ AGENT_TIMELINE_CHARS = {
     STATUS_WAITING_SUPERVISOR: "▒",
     STATUS_WAITING_USER: "░",
     STATUS_TERMINATED: "×",  # Small X - terminated
-    STATUS_ASLEEP: "z",  # Lowercase z for sleeping
+    STATUS_ASLEEP: "░",  # Light shade hatching (grey) - sleeping/paused
 }
 
 

--- a/tests/unit/test_time_tracking.py
+++ b/tests/unit/test_time_tracking.py
@@ -707,11 +707,11 @@ class TestSleepModeTimelineChar:
     """Test that sleep mode uses the correct timeline character."""
 
     def test_asleep_status_has_timeline_char(self):
-        """STATUS_ASLEEP should map to 'z' in timeline."""
+        """STATUS_ASLEEP should map to light shade hatching in timeline."""
         from overcode.status_constants import STATUS_ASLEEP, AGENT_TIMELINE_CHARS
 
         assert STATUS_ASLEEP in AGENT_TIMELINE_CHARS
-        assert AGENT_TIMELINE_CHARS[STATUS_ASLEEP] == "z"
+        assert AGENT_TIMELINE_CHARS[STATUS_ASLEEP] == "░"
 
     def test_asleep_status_has_emoji(self):
         """STATUS_ASLEEP should map to sleeping emoji."""


### PR DESCRIPTION
## Summary
- Changed the timeline character for sleeping agents from `z` to `░` (light shade)
- The existing "dim" color styling makes it appear as grey hatching
- Matches the visual style of other non-running states

## Visual Comparison
| Status | Character | Color |
|--------|-----------|-------|
| Running | █ | green |
| No instructions | ▓ | yellow |
| Waiting supervisor | ▒ | orange |
| Waiting user | ░ | red |
| Asleep | ░ | grey (dim) |
| Terminated | × | grey (dim) |

## Test plan
- [x] Unit tests pass
- [ ] Manual: View timeline with sleeping agent, verify grey hatching appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)