### PR TITLE
Add asleep status to timeline legend

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -472,6 +472,8 @@ class StatusTimeline(Static):
         content.append("inactive ", style="dim")
         content.append("░", style="red")
         content.append("waiting/away ", style="dim")
+        content.append("░", style="dim")
+        content.append("asleep ", style="dim")
         content.append("×", style="dim")
         content.append("terminated", style="dim")
 


### PR DESCRIPTION
## Summary
- Added the asleep status (grey ░) to the timeline legend
- Distinguishes it from the red ░ used for waiting/away

## Test plan
- [ ] Manual: View timeline, verify legend shows grey ░ for asleep

🤖 Generated with [Claude Code](https://claude.com/claude-code)