### PR TITLE
Fix priority icon spacing by adding variation selectors

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -993,10 +993,11 @@ class SessionSummary(Static, can_focus=True):
             content.append(f" 💰{s.agent_value:>4}", style=f"bold magenta{bg}")
         else:
             # Priority icon based on value relative to default 1000
+            # All emoji use variation selector (U+FE0F) for consistent width
             if s.agent_value > 1000:
-                content.append(" ⏫", style=f"bold red{bg}")  # High priority
+                content.append(" ⏫️", style=f"bold red{bg}")  # High priority
             elif s.agent_value < 1000:
-                content.append(" ⏬", style=f"bold blue{bg}")  # Low priority
+                content.append(" ⏬️", style=f"bold blue{bg}")  # Low priority
             else:
                 content.append(" ⏹️", style=f"dim{bg}")  # Normal
 


### PR DESCRIPTION
## Summary
- Added U+FE0F variation selectors to ⏫ and ⏬ to match ⏹️
- All three priority icons now have consistent character length (2)
- Fixes spacing misalignment before the `│` separator

## Root cause
- ⏫ and ⏬ were single Unicode characters (len=1)
- ⏹️ included the variation selector U+FE0F (len=2)
- This caused the TUI to miscalculate spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)