### PR TITLE
Fix stop emoji alignment by adding trailing space

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -993,13 +993,14 @@ class SessionSummary(Static, can_focus=True):
             content.append(f" 💰{s.agent_value:>4}", style=f"bold magenta{bg}")
         else:
             # Priority icon based on value relative to default 1000
-            # All emoji use variation selector (U+FE0F) for consistent width
+            # Note: Rich measures ⏹️ as 2 cells but ⏫️/⏬️ as 3 cells, so we add
+            # a trailing space to ⏹️ for alignment
             if s.agent_value > 1000:
                 content.append(" ⏫️", style=f"bold red{bg}")  # High priority
             elif s.agent_value < 1000:
                 content.append(" ⏬️", style=f"bold blue{bg}")  # Low priority
             else:
-                content.append(" ⏹️", style=f"dim{bg}")  # Normal
+                content.append(" ⏹️ ", style=f"dim{bg}")  # Normal (extra space for alignment)
 
         if not self.expanded:
             # Compact view: show content based on summary_content_mode (#74)


### PR DESCRIPTION
## Summary
- Added trailing space to ⏹️ (normal priority) to fix alignment with ⏫️/⏬️

## Root Cause
Rich's `console.measure()` returns different cell widths for these emoji:
- `⏫️` (up chevron): 3 cells
- `⏬️` (down chevron): 3 cells
- `⏹️` (stop button): **2 cells** ← the problem

This caused the vertical bar separator to appear 1 cell closer on normal priority rows.

## Fix
Added a trailing space to `" ⏹️ "` so it measures as 3 cells, matching the chevrons.

## Verification
```python
from rich.console import Console
console = Console()
print(console.measure(" ⏫️").maximum)  # 3
print(console.measure(" ⏬️").maximum)  # 3
print(console.measure(" ⏹️ ").maximum) # 3 (with trailing space)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)