### PR TITLE
Add color support to preview pane (#119)

### DIFF
--- a/src/overcode/implementations.py
+++ b/src/overcode/implementations.py
@@ -68,7 +68,8 @@ class RealTmux:
             if pane is None:
                 return None
             # capture_pane returns list of lines
-            captured = pane.capture_pane(start=-lines)
+            # escape_sequences=True preserves ANSI color codes for TUI rendering
+            captured = pane.capture_pane(start=-lines, escape_sequences=True)
             if isinstance(captured, list):
                 return '\n'.join(captured)
             return captured

--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -1132,13 +1132,14 @@ class PreviewPane(Static):
             # Calculate available lines based on widget height
             # Reserve 2 lines for header and some padding
             available_lines = max(10, self.size.height - 2) if self.size.height > 0 else 30
-            # Show last N lines of output - plain text, no decoration
+            # Show last N lines of output with ANSI color support
             # Truncate lines to pane width to match tmux display
             max_line_len = max(pane_width - 1, 40)  # Leave room for newline, minimum 40
             for line in self.content_lines[-available_lines:]:
                 # Truncate long lines to pane width
                 display_line = line[:max_line_len] if len(line) > max_line_len else line
-                content.append(display_line + "\n")
+                # Parse ANSI escape sequences to preserve colors from tmux
+                content.append(Text.from_ansi(display_line + "\n"))
 
         return content
 


### PR DESCRIPTION
## Summary
- Fixed preview pane rendering all output in black and white
- Enable ANSI escape sequence capture from tmux with `escape_sequences=True`
- Parse ANSI codes in preview pane rendering with `Text.from_ansi()`

## Problem
Two issues were causing colors to be lost:
1. `pane.capture_pane()` was not passing `escape_sequences=True`, so ANSI codes were stripped at capture time
2. `PreviewPane.render()` was appending lines as plain text without parsing ANSI escape sequences

## Test plan
- [ ] Open the TUI in list+preview mode
- [ ] Focus an agent that has colored output (e.g., syntax highlighting, status messages)
- [ ] Verify colors are now visible in the preview pane

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)