### PR TITLE
Fix preview pane line breaks with ANSI color support

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -1148,7 +1148,9 @@ class PreviewPane(Static):
                 # Truncate long lines to pane width
                 display_line = line[:max_line_len] if len(line) > max_line_len else line
                 # Parse ANSI escape sequences to preserve colors from tmux
-                content.append(Text.from_ansi(display_line + "\n"))
+                # Note: Text.from_ansi() strips trailing newlines, so add newline separately
+                content.append(Text.from_ansi(display_line))
+                content.append("\n")
 
         return content
 


### PR DESCRIPTION
## Summary
- Fix line breaks being lost in preview pane after PR #119 (color support)

## Problem
After merging PR #119 which added ANSI color support, all lines in the preview pane were mashed together at the top instead of appearing on separate lines.

## Root Cause
`Text.from_ansi()` strips trailing newlines from the input string. The original code was:
```python
content.append(Text.from_ansi(display_line + "\n"))
```

The `\n` was being stripped by `from_ansi()`, so no line breaks appeared.

## Fix
Append the newline separately after parsing ANSI codes:
```python
content.append(Text.from_ansi(display_line))
content.append("\n")
```

## Test plan
- [x] Verify preview pane shows content on separate lines
- [x] Verify colors still work in preview pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)