### PR TITLE
Fix status detection broken by ANSI color codes

### DIFF
--- a/src/overcode/status_patterns.py
+++ b/src/overcode/status_patterns.py
@@ -10,8 +10,27 @@ Claude's current state. Centralizing these makes them:
 Each pattern set includes documentation about when it's used and what it matches.
 """
 
+import re
 from dataclasses import dataclass, field
 from typing import List
+
+# Regex to match ANSI escape sequences (colors, cursor movement, etc.)
+ANSI_ESCAPE_PATTERN = re.compile(r'\x1b\[[0-9;]*[a-zA-Z]')
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from text.
+
+    This is needed because tmux capture_pane with escape_sequences=True
+    preserves color codes, but pattern matching needs plain text.
+
+    Args:
+        text: Text potentially containing ANSI escape sequences
+
+    Returns:
+        Text with all ANSI escape sequences removed
+    """
+    return ANSI_ESCAPE_PATTERN.sub('', text)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Fix status detection defaulting to inactive after PR #119 (color support)

## Problem
After PR #119 added `escape_sequences=True` to `capture_pane`, the pane content now contains ANSI escape codes (e.g., `\x1b[32m` for green). This broke pattern matching because:

- Pattern `">"` wouldn't match `"\x1b[32m>\x1b[0m"` (colored prompt)
- Pattern `"thinking"` wouldn't match `"\x1b[33mthinking\x1b[0m"` (colored text)

This caused status detection to fall through to the default case (inactive/no_instructions).

## Fix
- Add `strip_ansi()` function to `status_patterns.py` to remove ANSI escape sequences
- Strip ANSI codes from content before pattern matching in `detect_status()`
- Keep raw content (with colors) for display in preview pane

## Test plan
- [x] All status detector tests pass
- [x] Verified `strip_ansi()` correctly removes color codes
- [x] Pattern matching works on cleaned text

🤖 Generated with [Claude Code](https://claude.com/claude-code)