### PR TITLE
Fix slow responsiveness of 'g' key for terminated agents toggle

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -2612,6 +2612,17 @@ class SupervisorTUI(App):
         self._prefs.show_terminated = self.show_terminated
         self._save_prefs()
 
+        # Refresh session widgets to show/hide terminated sessions
+        self.update_session_widgets()
+
+        # Notify user
+        status = "visible" if self.show_terminated else "hidden"
+        count = len(self._terminated_sessions)
+        if count > 0:
+            self.notify(f"Killed sessions: {status} ({count})", severity="information")
+        else:
+            self.notify(f"Killed sessions: {status}", severity="information")
+
     def action_jump_to_attention(self) -> None:
         """Jump to next session needing attention.
 
@@ -2674,19 +2685,6 @@ class SupervisorTUI(App):
         total = len(self._attention_jump_list)
         status = getattr(target_widget, 'current_status', 'unknown')
         self.notify(f"Attention {pos}/{total}: {target_widget.session.name} ({status})", severity="information")
-
-        # Update subtitle to show state
-        self._update_subtitle()
-
-        # Refresh session widgets to show/hide terminated sessions
-        self.update_session_widgets()
-
-        status = "visible" if self.show_terminated else "hidden"
-        count = len(self._terminated_sessions)
-        if count > 0:
-            self.notify(f"Killed sessions: {status} ({count})", severity="information")
-        else:
-            self.notify(f"Killed sessions: {status}", severity="information")
 
     def action_toggle_hide_asleep(self) -> None:
         """Toggle hiding sleeping agents from display."""


### PR DESCRIPTION
## Summary
- Fix 5-second delay when pressing 'g' to toggle terminated agents view

## Problem
Pressing 'g' to show/hide terminated agents was extremely slow (up to 5 seconds). The UI only updated when the next periodic refresh happened.

## Root Cause
The `action_toggle_show_terminated` method only:
1. Toggled the `show_terminated` flag
2. Saved the preference

It never called `update_session_widgets()` to refresh the display immediately.

The code to refresh widgets and show the notification was incorrectly placed at the end of `action_jump_to_attention` instead of in `action_toggle_show_terminated`.

## Fix
Move the refresh and notification code to `action_toggle_show_terminated` where it belongs.

## Test plan
- [x] Press 'g' - terminated agents toggle should be instant now
- [x] Notification should appear immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)