### PR TITLE
Fix context window cross-contamination between agents (#119)

### DIFF
--- a/src/overcode/session_manager.py
+++ b/src/overcode/session_manager.py
@@ -98,6 +98,10 @@ class Session:
     # Human annotation - user's notes about this agent (#74)
     human_annotation: str = ""
 
+    # Claude sessionIds owned by this overcode session (#119)
+    # Used to accurately calculate context window for this specific agent
+    claude_session_ids: List[str] = field(default_factory=list)
+
     def to_dict(self) -> dict:
         data = asdict(self)
         # Convert stats to dict
@@ -627,3 +631,32 @@ class SessionManager:
     def set_human_annotation(self, session_id: str, annotation: str):
         """Set human annotation for a session (#74)."""
         self.update_session(session_id, human_annotation=annotation)
+
+    def add_claude_session_id(self, session_id: str, claude_session_id: str) -> bool:
+        """Add a Claude sessionId to a session's owned list if not already present.
+
+        This tracks which Claude sessionIds belong to this overcode agent,
+        enabling accurate context window calculation when multiple agents
+        run in the same directory (#119).
+
+        Args:
+            session_id: The overcode session ID
+            claude_session_id: The Claude Code sessionId to add
+
+        Returns:
+            True if the sessionId was added, False if already present or session not found
+        """
+        session = self.get_session(session_id)
+        if not session or claude_session_id in session.claude_session_ids:
+            return False
+
+        def do_update(state):
+            if session_id in state:
+                ids = state[session_id].get('claude_session_ids', [])
+                if claude_session_id not in ids:
+                    ids.append(claude_session_id)
+                    state[session_id]['claude_session_ids'] = ids
+            return state
+
+        self._atomic_update(do_update)
+        return True


### PR DESCRIPTION
## Summary
- Fix context window showing wrong agent's data when multiple agents run in same directory
- Track which Claude sessionIds belong to each overcode agent
- Only use owned sessionIds for context window calculation

## Problem
When multiple overcode agents run in the same directory, the context window calculation was matching ALL Claude sessionIds for that directory based on `(directory, timestamp >= start_time)`. This caused Agent A to show Agent B's context window.

## Solution
1. **Track owned sessionIds**: Add `claude_session_ids` field to Session dataclass
2. **Discover new sessionIds**: Add `get_current_session_id_for_directory()` helper
3. **Use only owned IDs for context**: Modify `get_session_stats()` to only calculate context from explicitly tracked sessionIds
4. **Capture sessionIds in daemon**: Monitor daemon captures Claude sessionIds during stats sync

## Backward Compatibility
- Sessions without `claude_session_ids` default to empty list → context shows 0%
- SessionIds are captured gradually as daemon runs
- Total token counting is unaffected (still uses directory+timestamp matching)

## Also Fixes #116
This also fixes context window not updating after `/clear`:
1. User runs `/clear` → Claude Code creates new sessionId
2. User sends prompt → entry appears in history.jsonl
3. Monitor daemon discovers new sessionId and adds to `claude_session_ids`
4. Context calculation uses new session's (low) context

## Test plan
- [ ] Start two agents in the same directory
- [ ] Send messages to both to build up different context sizes
- [ ] Verify each agent shows its own context window percentage
- [ ] Run `/clear` in one agent, verify its context resets while other is unchanged

Closes #119
Supersedes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)