### PR TITLE
Fix bell indicator appearing on sleeping sessions (#120)

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -2230,10 +2230,11 @@ class SupervisorTUI(App):
                 # Update previous status for next round
                 self._previous_statuses[session_id] = status
 
-                # Update widget's unvisited state
+                # Update widget's unvisited state (never show bell on asleep sessions #120)
                 is_unvisited_stalled = (
                     status == STATUS_WAITING_USER and
-                    session_id not in self._prefs.visited_stalled_agents
+                    session_id not in self._prefs.visited_stalled_agents and
+                    not widget.session.is_asleep
                 )
                 widget.is_unvisited_stalled = is_unvisited_stalled
 


### PR DESCRIPTION
## Summary
- Bell indicators (🔔) were incorrectly appearing on sleeping/asleep sessions
- Added `is_asleep` check to the unvisited stalled detection logic so bells never show on asleep sessions

Fixes #120

## Test plan
- [x] All existing tests pass
- [ ] Launch an agent, put it to sleep, verify no bell appears even if it was in `waiting_user` state

🤖 Generated with [Claude Code](https://claude.com/claude-code)