### PR TITLE
Clear AI summaries immediately when summarizer is disabled (#136)

### DIFF
--- a/src/overcode/tui_actions/daemon.py
+++ b/src/overcode/tui_actions/daemon.py
@@ -93,6 +93,7 @@ class DaemonActionsMixin:
     def action_toggle_summarizer(self) -> None:
         """Toggle the AI Summarizer on/off."""
         from ..summarizer_client import SummarizerClient
+        from ..tui_widgets import SessionSummary
 
         # Check if summarizer is available (OPENAI_API_KEY set)
         if not SummarizerClient.is_available():
@@ -107,6 +108,9 @@ class DaemonActionsMixin:
             if not self._summarizer._client:
                 self._summarizer._client = SummarizerClient()
             self.notify("AI Summarizer enabled", severity="information")
+            # Update all widgets to show summarizer is enabled
+            for widget in self.query(SessionSummary):
+                widget.summarizer_enabled = True
             # Trigger an immediate update
             self._update_summaries_async()
         else:
@@ -114,6 +118,14 @@ class DaemonActionsMixin:
             if self._summarizer._client:
                 self._summarizer._client.close()
                 self._summarizer._client = None
+            # Clear cached summaries
+            self._summaries = {}
+            # Update all widgets to clear summaries and show disabled state
+            for widget in self.query(SessionSummary):
+                widget.ai_summary_short = ""
+                widget.ai_summary_context = ""
+                widget.summarizer_enabled = False
+                widget.refresh()
             self.notify("AI Summarizer disabled", severity="information")
 
         # Refresh status bar

--- a/src/overcode/tui_widgets/session_summary.py
+++ b/src/overcode/tui_widgets/session_summary.py
@@ -70,6 +70,7 @@ class SessionSummary(Static, can_focus=True):
         self.ai_summary_short: str = ""  # Short: current activity (~50 chars)
         self.ai_summary_context: str = ""  # Context: wider context (~80 chars)
         self.monochrome: bool = False  # B&W mode for terminals with ANSI issues (#138)
+        self.summarizer_enabled: bool = False  # Track if summarizer is enabled
         self.pane_content: List[str] = []  # Cached pane content
         self.claude_stats: Optional[ClaudeSessionStats] = None  # Token/interaction stats
         self.git_diff_stats: Optional[tuple] = None  # (files, insertions, deletions)
@@ -426,12 +427,16 @@ class SessionSummary(Static, can_focus=True):
                 # ai_long: show context summary (📖 icon - wider context/goal from AI)
                 if self.ai_summary_context:
                     content.append(f"📖 {self.ai_summary_context[:remaining-3]}", style=mono(f"bold italic{bg}", "bold"))
+                elif not self.summarizer_enabled:
+                    content.append("📖 (summarizer disabled - press 'a')", style=mono(f"dim italic{bg}", "dim"))
                 else:
                     content.append("📖 (awaiting context...)", style=mono(f"dim italic{bg}", "dim"))
             else:
                 # ai_short: show short summary (💬 icon - current activity from AI)
                 if self.ai_summary_short:
                     content.append(f"💬 {self.ai_summary_short[:remaining-3]}", style=mono(f"bold italic{bg}", "bold"))
+                elif not self.summarizer_enabled:
+                    content.append("💬 (summarizer disabled - press 'a')", style=mono(f"dim italic{bg}", "dim"))
                 else:
                     content.append("💬 (awaiting summary...)", style=mono(f"dim italic{bg}", "dim"))
 


### PR DESCRIPTION
## Summary
- Add `summarizer_enabled` property to SessionSummary widget to track state
- Display "(summarizer disabled - press 'a')" when summarizer is off instead of "awaiting..."
- Clear all cached summaries and widget values immediately when summarizer is disabled
- Initialize `summarizer_enabled` state properly for new widgets

## Test plan
- [ ] Enable summarizer with `a` - verify summaries appear
- [ ] Disable summarizer with `a` - verify summaries immediately disappear and show "summarizer disabled"
- [ ] Re-enable summarizer - verify summaries start appearing again

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)