### PR TITLE
Fix delayed terminated agent detection on 'g' toggle (#137)

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -691,9 +691,11 @@ class SupervisorTUI(
                 if self.view_mode == "list_preview":
                     widget.add_class("list-mode")
                     widget.expanded = False  # Force collapsed in list mode
-                # Mark terminated sessions with visual styling
+                # Mark terminated sessions with visual styling and status
                 if session.status == "terminated":
                     widget.add_class("terminated")
+                    widget.detected_status = "terminated"
+                    widget.current_activity = "(tmux window no longer exists)"
                 container.mount(widget)
                 # NOTE: Don't call update_status() here - it does blocking tmux calls
                 # The 250ms interval (update_all_statuses) will update status shortly

--- a/src/overcode/tui_widgets/session_summary.py
+++ b/src/overcode/tui_widgets/session_summary.py
@@ -59,9 +59,13 @@ class SessionSummary(Static, can_focus=True):
         super().__init__(*args, **kwargs)
         self.session = session
         self.status_detector = status_detector
-        # Initialize from persisted session state, not hardcoded "running"
-        self.detected_status = session.stats.current_state if session.stats.current_state else "running"
-        self.current_activity = "Initializing..."
+        # Initialize from session status (for terminated) or persisted state
+        if session.status == "terminated":
+            self.detected_status = "terminated"
+            self.current_activity = "(tmux window no longer exists)"
+        else:
+            self.detected_status = session.stats.current_state if session.stats.current_state else "running"
+            self.current_activity = "Initializing..."
         # AI-generated summaries (from daemon's SummarizerComponent)
         self.ai_summary_short: str = ""  # Short: current activity (~50 chars)
         self.ai_summary_context: str = ""  # Context: wider context (~80 chars)


### PR DESCRIPTION
## Summary
- Initialize widgets for terminated sessions with correct status immediately
- Set `detected_status="terminated"` in widget `__init__` when `session.status` is terminated
- Set `current_activity` to explain the state ("tmux window no longer exists")
- Also set these values when creating widgets in `update_session_widgets()`

Previously, terminated session widgets would show incorrect status until the next async status update cycle (~250ms), which could feel laggy.

## Test plan
- [ ] Kill an agent with `x`
- [ ] Press `g` to show terminated agents
- [ ] Verify the terminated agent immediately shows with correct "terminated" status

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)