### PR TITLE
Fix ! commands not triggering bash mode switch (#139)

### DIFF
--- a/src/overcode/implementations.py
+++ b/src/overcode/implementations.py
@@ -85,9 +85,23 @@ class RealTmux:
             # For Claude Code: text and Enter must be sent as SEPARATE commands
             # with a small delay, otherwise Claude Code doesn't process the Enter.
             if keys:
-                pane.send_keys(keys, enter=False)
-                # Small delay for Claude Code to process text
-                time.sleep(0.1)
+                # Special handling for ! commands (#139)
+                # Claude Code requires ! to be sent separately to trigger mode switch
+                # to bash mode before receiving the rest of the command
+                if keys.startswith('!') and len(keys) > 1:
+                    # Send ! first
+                    pane.send_keys('!', enter=False)
+                    # Wait for mode switch to process
+                    time.sleep(0.15)
+                    # Send the rest (without the !)
+                    rest = keys[1:]
+                    if rest:
+                        pane.send_keys(rest, enter=False)
+                        time.sleep(0.1)
+                else:
+                    pane.send_keys(keys, enter=False)
+                    # Small delay for Claude Code to process text
+                    time.sleep(0.1)
 
             if enter:
                 pane.send_keys('', enter=True)

--- a/src/overcode/tmux_manager.py
+++ b/src/overcode/tmux_manager.py
@@ -133,9 +133,23 @@ class TmuxManager:
 
             # Send text first (if any)
             if keys:
-                pane.send_keys(keys, enter=False)
-                # Small delay for Claude Code to process text
-                time.sleep(0.1)
+                # Special handling for ! commands (#139)
+                # Claude Code requires ! to be sent separately to trigger mode switch
+                # to bash mode before receiving the rest of the command
+                if keys.startswith('!') and len(keys) > 1:
+                    # Send ! first
+                    pane.send_keys('!', enter=False)
+                    # Wait for mode switch to process
+                    time.sleep(0.15)
+                    # Send the rest (without the !)
+                    rest = keys[1:]
+                    if rest:
+                        pane.send_keys(rest, enter=False)
+                        time.sleep(0.1)
+                else:
+                    pane.send_keys(keys, enter=False)
+                    # Small delay for Claude Code to process text
+                    time.sleep(0.1)
 
             # Send Enter separately
             if enter:


### PR DESCRIPTION
## Summary
- Add special handling for commands starting with `!` in tmux send-keys
- Send `!` first and wait 150ms for Claude Code to switch to bash mode
- Then send the rest of the command

When sending `!` commands in one go via tmux send-keys, Claude Code doesn't process the mode switch and the command gets sent as regular text instead of being executed as bash.

## Test plan
- [ ] Send a `!` command via the TUI command bar (e.g., `!ls -la`)
- [ ] Verify Claude Code switches to bash mode and executes the command
- [ ] Verify normal text commands (without `!`) still work

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)