### PR TITLE
Fix summary content mode out of sync on filter change (#140)

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -687,6 +687,8 @@ class SupervisorTUI(
                 widget.detail_lines = self.DETAIL_LEVELS[self.detail_level_index]
                 # Apply current summary detail level
                 widget.summary_detail = self.SUMMARY_LEVELS[self.summary_level_index]
+                # Apply current summary content mode (#140)
+                widget.summary_content_mode = self.summary_content_mode
                 # Apply list-mode class if in list_preview view
                 if self.view_mode == "list_preview":
                     widget.add_class("list-mode")


### PR DESCRIPTION
## Summary
- Apply `summary_content_mode` when creating new session widgets
- Previously, newly created widgets (e.g., when showing terminated sessions with `g`) would use the default mode instead of the current setting

When changing filter criteria (show/hide sleeping/terminated agents), newly added widgets would show a different summary mode than existing widgets.

## Test plan
- [ ] Set summary mode to "orders" with `l` key
- [ ] Press `g` to show terminated agents
- [ ] Verify new terminated agent widgets show "orders" mode, not AI summary

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)