### PR TITLE
Add R key to restart agent (#133)

### DIFF
--- a/src/overcode/tui_widgets/help_overlay.py
+++ b/src/overcode/tui_widgets/help_overlay.py
@@ -43,8 +43,9 @@ class HelpOverlay(Static):
 ║  i/:     Send instruction        o       Set standing orders                 ║
 ║  I       Edit annotation         Enter   Approve (send Enter)                ║
 ║  1-5     Send number             n       New agent                           ║
-║  x       Kill agent              z       Toggle sleep                        ║
-║  b       Jump to red/attention   V       Edit agent value                    ║
+║  x       Kill agent              R       Restart agent                       ║
+║  z       Toggle sleep            V       Edit agent value                    ║
+║  b       Jump to red/attention                                               ║
 ║                                                                              ║
 ║  DAEMON CONTROL                                                              ║
 ║  ──────────────────────────────────────────────────────────────────────────  ║


### PR DESCRIPTION
## Summary
- Add `Shift+R` keybinding to restart the focused agent
- Uses confirmation pattern (press R twice within 3 seconds)
- Sends Ctrl-C to kill current Claude process, then restarts with same config
- Clears `claude_session_ids` for fresh context window tracking

## Implementation
- Added `_pending_restart` state variable for confirmation flow
- Added `action_restart_focused()` in session.py mixin
- Added `_execute_restart()` in tui.py
- Updated help overlay with new keybinding

## Test plan
- [x] Run `pytest tests/unit/test_tui.py` - all pass
- [x] Run `pytest tests/unit/test_session_manager.py` - all pass
- [ ] Manual test: Focus agent, press R twice, verify it restarts

Fixes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)