### PR TITLE
Prevent putting running agents into sleep mode (#158)

### DIFF
--- a/src/overcode/tui_actions/session.py
+++ b/src/overcode/tui_actions/session.py
@@ -33,8 +33,11 @@ class SessionActionsMixin:
         Sleep mode marks an agent as 'asleep' (human doesn't want it to do anything).
         Sleeping agents are excluded from stats calculations.
         Press z again to wake the agent.
+
+        Note: Cannot put a running agent to sleep (#158).
         """
         from ..tui_widgets import SessionSummary
+        from ..status_constants import STATUS_RUNNING
         focused = self.focused
         if not isinstance(focused, SessionSummary):
             self.notify("No agent focused", severity="warning")
@@ -42,6 +45,11 @@ class SessionActionsMixin:
 
         session = focused.session
         new_asleep_state = not session.is_asleep
+
+        # Prevent putting a running agent to sleep (#158)
+        if new_asleep_state and focused.detected_status == STATUS_RUNNING:
+            self.notify("Cannot put a running agent to sleep", severity="warning")
+            return
 
         # Update the session in the session manager
         self.session_manager.update_session(session.id, is_asleep=new_asleep_state)

--- a/tests/unit/test_tui_actions_session.py
+++ b/tests/unit/test_tui_actions_session.py
@@ -1,0 +1,116 @@
+"""
+Unit tests for TUI session actions.
+
+Tests session control logic that can be isolated from the full TUI.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestToggleSleep:
+    """Test action_toggle_sleep method."""
+
+    def test_blocks_sleep_on_running_agent(self):
+        """Should prevent putting a running agent to sleep (#158)."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+        from overcode.status_constants import STATUS_RUNNING
+
+        mock_session = MagicMock()
+        mock_session.is_asleep = False
+        mock_session.name = "test-agent"
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+        mock_widget.detected_status = STATUS_RUNNING
+
+        mock_tui = MagicMock()
+        mock_tui.focused = mock_widget
+
+        SessionActionsMixin.action_toggle_sleep(mock_tui)
+
+        # Should show warning and not toggle sleep
+        mock_tui.notify.assert_called_once()
+        assert "Cannot put a running agent to sleep" in mock_tui.notify.call_args[0][0]
+        assert mock_tui.notify.call_args[1]["severity"] == "warning"
+        # Should not update session manager
+        mock_tui.session_manager.update_session.assert_not_called()
+
+    def test_allows_sleep_on_non_running_agent(self):
+        """Should allow putting a non-running agent to sleep."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+        from overcode.status_constants import STATUS_WAITING_USER
+
+        mock_session = MagicMock()
+        mock_session.is_asleep = False
+        mock_session.name = "test-agent"
+        mock_session.id = "session-123"
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+        mock_widget.detected_status = STATUS_WAITING_USER
+
+        mock_tui = MagicMock()
+        mock_tui.focused = mock_widget
+
+        SessionActionsMixin.action_toggle_sleep(mock_tui)
+
+        # Should update session to asleep
+        mock_tui.session_manager.update_session.assert_called_once_with(
+            "session-123", is_asleep=True
+        )
+        assert mock_session.is_asleep is True
+        mock_tui.notify.assert_called_once()
+        assert "is now asleep" in mock_tui.notify.call_args[0][0]
+
+    def test_allows_wake_even_if_running(self):
+        """Should allow waking up an asleep agent regardless of detected status."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+        from overcode.status_constants import STATUS_RUNNING
+
+        mock_session = MagicMock()
+        mock_session.is_asleep = True  # Already asleep
+        mock_session.name = "test-agent"
+        mock_session.id = "session-123"
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+        # Even if detected_status shows running, wake should work
+        mock_widget.detected_status = STATUS_RUNNING
+
+        mock_tui = MagicMock()
+        mock_tui.focused = mock_widget
+
+        SessionActionsMixin.action_toggle_sleep(mock_tui)
+
+        # Should wake up the agent
+        mock_tui.session_manager.update_session.assert_called_once_with(
+            "session-123", is_asleep=False
+        )
+        assert mock_session.is_asleep is False
+        mock_tui.notify.assert_called_once()
+        assert "is now awake" in mock_tui.notify.call_args[0][0]
+
+    def test_no_agent_focused(self):
+        """Should show warning when no agent is focused."""
+        from overcode.tui_actions.session import SessionActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.focused = None  # No agent focused
+
+        SessionActionsMixin.action_toggle_sleep(mock_tui)
+
+        mock_tui.notify.assert_called_once()
+        assert "No agent focused" in mock_tui.notify.call_args[0][0]
+        assert mock_tui.notify.call_args[1]["severity"] == "warning"
+
+
+# =============================================================================
+# Run tests directly
+# =============================================================================
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Add guard in `action_toggle_sleep()` to block putting running agents to sleep
- Show warning notification "Cannot put a running agent to sleep" when attempted
- Waking up sleeping agents still works regardless of detected status

Fixes #158

## Test plan
- [x] Unit tests added for all scenarios
- [ ] Manually test pressing `z` on a running agent - should show warning
- [ ] Manually test pressing `z` on a non-running agent - should sleep
- [ ] Manually test pressing `z` on a sleeping agent - should wake

🤖 Generated with [Claude Code](https://claude.com/claude-code)