### PR TITLE
Fix monochrome mode to affect preview panes instead of summary lines

### DIFF
--- a/src/overcode/settings.py
+++ b/src/overcode/settings.py
@@ -430,6 +430,7 @@ class TUIPreferences:
                     sort_mode=data.get("sort_mode", "alphabetical"),
                     summary_content_mode=data.get("summary_content_mode", "ai_short"),
                     baseline_minutes=data.get("baseline_minutes", 0),
+                    monochrome=data.get("monochrome", False),
                     show_cost=data.get("show_cost", False),
                     visited_stalled_agents=set(data.get("visited_stalled_agents", [])),
                 )
@@ -456,6 +457,7 @@ class TUIPreferences:
                     "sort_mode": self.sort_mode,
                     "summary_content_mode": self.summary_content_mode,
                     "baseline_minutes": self.baseline_minutes,
+                    "monochrome": self.monochrome,
                     "show_cost": self.show_cost,
                     "visited_stalled_agents": list(self.visited_stalled_agents),
                 }, f, indent=2)

--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -347,6 +347,13 @@ class SupervisorTUI(
         except NoMatches:
             pass
 
+        # Apply monochrome preference to preview pane (#138)
+        try:
+            preview = self.query_one("#preview-pane", PreviewPane)
+            preview.monochrome = self._prefs.monochrome
+        except NoMatches:
+            pass
+
         # Set view_mode from preferences (triggers watch_view_mode)
         self.view_mode = self._prefs.view_mode
 

--- a/src/overcode/tui_actions/view.py
+++ b/src/overcode/tui_actions/view.py
@@ -291,11 +291,11 @@ class ViewActionsMixin:
         """Toggle monochrome (B&W) mode for terminals with ANSI issues (#138).
 
         When enabled:
-        - Removes color styling from session widgets
-        - Uses simple gray/white text only
+        - Strips ANSI color codes from preview pane and tmux output
+        - Uses plain text rendering for terminal content
         - Helps with terminals that garble ANSI color codes
         """
-        from ..tui_widgets import SessionSummary
+        from ..tui_widgets import SessionSummary, PreviewPane
 
         self.monochrome = not self.monochrome
 
@@ -309,7 +309,15 @@ class ViewActionsMixin:
         else:
             self.remove_class("monochrome")
 
-        # Update all session widgets to use monochrome rendering
+        # Update preview pane to use monochrome rendering
+        try:
+            preview = self.query_one("#preview-pane", PreviewPane)
+            preview.monochrome = self.monochrome
+            preview.refresh()
+        except NoMatches:
+            pass
+
+        # Update all session widgets to use monochrome rendering for expanded pane content
         for widget in self.query(SessionSummary):
             widget.monochrome = self.monochrome
             widget.refresh()

--- a/src/overcode/tui_widgets/session_summary.py
+++ b/src/overcode/tui_widgets/session_summary.py
@@ -500,9 +500,15 @@ class SessionSummary(Static, can_focus=True):
             content.append("  ")  # Indent
             # Truncate long lines and style based on content
             display_line = line[:100] + "..." if len(line) > 100 else line
-            prefix_style, content_style = style_pane_line(line)
-            content.append("│ ", style=prefix_style)
-            content.append(display_line, style=content_style)
+            if self.monochrome:
+                # Strip ANSI codes and use plain styling
+                plain_line = Text.from_ansi(display_line).plain
+                content.append("│ ", style="dim")
+                content.append(plain_line)
+            else:
+                prefix_style, content_style = style_pane_line(line)
+                content.append("│ ", style=prefix_style)
+                content.append(display_line, style=content_style)
 
         # If no pane content and no standing instructions shown above, show placeholder
         if not pane_lines and not s.standing_instructions:


### PR DESCRIPTION
## Summary
- Fixes monochrome mode (M key) to strip ANSI colors from preview panes and tmux window content, not the summary lines
- Adds persistence for monochrome on/off setting to saved preferences

## Changes
- Add `monochrome` reactive property to `PreviewPane` widget
- Strip ANSI colors from preview pane content when monochrome is enabled
- Strip ANSI colors from expanded session pane content in `SessionSummary`
- Propagate monochrome setting to `PreviewPane` in toggle action
- Initialize `PreviewPane` monochrome from saved preferences on mount
- Add `monochrome` to `TUIPreferences` load/save methods (was defined but not persisted)

## Test plan
- [ ] Toggle monochrome mode with M key
- [ ] Verify preview pane strips ANSI colors when enabled
- [ ] Verify expanded session content strips ANSI colors when enabled
- [ ] Verify setting persists across TUI restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)