### PR TITLE
Fix missing tui.tcss in package distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overcode"
-version = "0.1.4"
+version = "0.1.5"
 description = "A supervisor for managing multiple Claude Code instances in tmux"
 authors = [
     {name = "Mike Bond"}
@@ -68,7 +68,7 @@ tui-eye = "overcode.testing.tui_eye:main"
 where = ["src"]
 
 [tool.setuptools.package-data]
-overcode = ["*.md", "*.sh"]
+overcode = ["*.md", "*.sh", "*.tcss"]
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
## Summary
- Add `*.tcss` to package-data patterns in pyproject.toml so the CSS file is included in the distribution
- Bump version to 0.1.5

## Problem
Running `uvx overcode monitor` fails with:
```
StylesheetError: unable to read CSS file '.../site-packages/overcode/tui.tcss'
```

The CSS file was not being included when the package was built and published to PyPI.

## Test plan
- [ ] Install via `uvx overcode monitor` after publishing and verify no StylesheetError

🤖 Generated with [Claude Code](https://claude.com/claude-code)