### PR TITLE
Add smoke test before publishing to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,8 +29,46 @@ jobs:
           name: dist
           path: dist/
 
-  publish:
+  smoke-test:
     needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install built wheel
+        run: pip install dist/*.whl
+
+      - name: Verify CLI entry points work
+        run: |
+          overcode --help
+          overcode monitor --help
+
+      - name: Verify package data files included
+        run: |
+          python -c "
+          import importlib.resources as resources
+          import overcode
+
+          # List all files that should be in the package
+          expected = ['tui.tcss']
+
+          pkg_path = resources.files(overcode)
+          for f in expected:
+              assert (pkg_path / f).is_file(), f'Missing package data: {f}'
+          print('All package data files present')
+          "
+
+  publish:
+    needs: [build, smoke-test]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:


### PR DESCRIPTION
## Summary
- Add `smoke-test` job to publish workflow that tests the built wheel before publishing
- Verifies TUI and CLI imports work correctly after installing from the wheel

## Problem
PR #166 fixed a bug where `tui.tcss` wasn't included in the package, causing `uvx overcode monitor` to crash on launch. This wasn't caught because:

1. Tests use editable install (`pip install -e`) which runs from source
2. Publish workflow had no verification step before uploading to PyPI

## Solution
Add a smoke test job between build and publish that:
1. Downloads the built wheel
2. Installs it (non-editable)
3. Verifies basic imports work

This catches packaging issues (missing files, broken imports) before they reach PyPI.

## Cost
- Only runs on releases, not every push
- Adds ~10 seconds to the release workflow

## Test plan
- [ ] Merge #166 first (the fix)
- [ ] Merge this PR
- [ ] Next release will run the smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)