### PR TITLE
Add Escape key to interrupt running Claude agent

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -157,6 +157,8 @@ class SupervisorTUI(
         ("n", "new_agent", "New agent"),
         # Send Enter to focused agent (for approvals)
         ("enter", "send_enter_to_focused", "Send Enter"),
+        # Send Escape to focused agent (for interrupting)
+        ("escape", "send_escape_to_focused", "Send Escape"),
         # Send number keys 1-5 to focused agent (for numbered prompts)
         ("1", "send_1_to_focused", "Send 1"),
         ("2", "send_2_to_focused", "Send 2"),

--- a/src/overcode/tui_actions/input.py
+++ b/src/overcode/tui_actions/input.py
@@ -36,6 +36,27 @@ class InputActionsMixin:
         else:
             self.notify(f"Failed to send Enter to {session_name}", severity="error")
 
+    def action_send_escape_to_focused(self) -> None:
+        """Send Escape keypress to the focused agent (for interrupting)."""
+        from ..tui_widgets import SessionSummary
+        from ..launcher import ClaudeLauncher
+
+        focused = self.focused
+        if not isinstance(focused, SessionSummary):
+            self.notify("No agent focused", severity="warning")
+            return
+
+        session_name = focused.session.name
+        launcher = ClaudeLauncher(
+            tmux_session=self.tmux_session,
+            session_manager=self.session_manager
+        )
+
+        if launcher.send_to_session(session_name, "escape"):
+            self.notify(f"Sent Escape to {session_name}", severity="information")
+        else:
+            self.notify(f"Failed to send Escape to {session_name}", severity="error")
+
     def _is_freetext_option(self, pane_content: str, key: str) -> bool:
         """Check if a numbered menu option is a free-text instruction option.
 

--- a/src/overcode/tui_widgets/help_overlay.py
+++ b/src/overcode/tui_widgets/help_overlay.py
@@ -42,10 +42,11 @@ class HelpOverlay(Static):
 ║  ──────────────────────────────────────────────────────────────────────────  ║
 ║  i/:     Send instruction        o       Set standing orders                 ║
 ║  I       Edit annotation         Enter   Approve (send Enter)                ║
-║  1-5     Send number             n       New agent                           ║
-║  x       Kill agent              R       Restart agent                       ║
-║  z       Toggle sleep            V       Edit agent value                    ║
-║  b       Jump to red/attention   H       Handover all (2x) → draft PR        ║
+║  1-5     Send number             Esc     Interrupt agent                     ║
+║  n       New agent               x       Kill agent                          ║
+║  R       Restart agent           z       Toggle sleep                        ║
+║  V       Edit agent value        b       Jump to red/attention               ║
+║  H       Handover all (2x) → draft PR                                        ║
 ║                                                                              ║
 ║  DAEMON CONTROL                                                              ║
 ║  ──────────────────────────────────────────────────────────────────────────  ║


### PR DESCRIPTION
## Summary
- Adds `Esc` key binding to send Escape to the focused Claude agent
- Follows the same pattern as existing `Enter` and `1-5` number key passthrough
- Updates help overlay to document the new hotkey

This allows users to interrupt a running Claude instance without Ctrl+C (which overcode intercepts for its own use).

Closes #163

## Test plan
- [x] Tests pass
- [ ] Manual test: Start a Claude agent running a long task, press `Esc`, verify it interrupts

🤖 Generated with [Claude Code](https://claude.com/claude-code)