### PR TITLE
Add time-context command for Claude Code time awareness hook

### DIFF
--- a/src/overcode/cli.py
+++ b/src/overcode/cli.py
@@ -457,6 +457,24 @@ def show(
                 rprint(f"[dim]No pane output available[/dim]")
 
 
+@app.command("time-context")
+def time_context():
+    """Output a compact time-awareness line for Claude Code hooks.
+
+    Called by a UserPromptSubmit hook on every prompt. Outputs a single
+    line with clock, presence, office hours, uptime, and heartbeat info.
+    Silently exits when not in an overcode-managed session (env vars missing).
+    """
+    from .time_context import get_agent_identity, generate_time_context
+
+    name, tmux = get_agent_identity()
+    if not name or not tmux:
+        raise typer.Exit(0)
+
+    line = generate_time_context(tmux, name)
+    print(line)
+
+
 @app.command()
 def instruct(
     name: Annotated[
@@ -1017,6 +1035,12 @@ CONFIG_TEMPLATE = """\
 #     - name: "Full Day"
 #       start: "09:00"
 #       end: "17:00"
+
+# Time context hook settings (for 'overcode time-context')
+# time_context:
+#   office_start: 9
+#   office_end: 17
+#   heartbeat_interval_minutes: 15  # omit to disable
 """
 
 

--- a/src/overcode/config.py
+++ b/src/overcode/config.py
@@ -185,3 +185,26 @@ def get_web_time_presets() -> list:
         {"name": "Evening", "start": "18:00", "end": "22:00"},
         {"name": "All Time", "start": None, "end": None},
     ]
+
+
+def get_time_context_config() -> dict:
+    """Get time context configuration for the time-context hook.
+
+    Config format in ~/.overcode/config.yaml:
+        time_context:
+          office_start: 9
+          office_end: 17
+          heartbeat_interval_minutes: 15  # omit to disable
+
+    Returns:
+        Dict with office_start (int), office_end (int),
+        heartbeat_interval_minutes (Optional[int])
+    """
+    config = load_config()
+    tc = config.get("time_context", {})
+
+    return {
+        "office_start": tc.get("office_start", 9),
+        "office_end": tc.get("office_end", 17),
+        "heartbeat_interval_minutes": tc.get("heartbeat_interval_minutes"),
+    }

--- a/src/overcode/launcher.py
+++ b/src/overcode/launcher.py
@@ -138,12 +138,15 @@ class ClaudeLauncher:
         elif skip_permissions:
             claude_cmd.extend(["--permission-mode", "dontAsk"])
 
+        # Prepend overcode env vars so the agent knows its identity
+        env_prefix = f"OVERCODE_SESSION_NAME={name} OVERCODE_TMUX_SESSION={self.tmux.session_name}"
+
         # If MOCK_SCENARIO is set, prepend it to the command for testing
         mock_scenario = os.environ.get("MOCK_SCENARIO")
         if mock_scenario:
-            cmd_str = f"MOCK_SCENARIO={mock_scenario} python {' '.join(claude_cmd)}"
+            cmd_str = f"MOCK_SCENARIO={mock_scenario} {env_prefix} python {' '.join(claude_cmd)}"
         else:
-            cmd_str = " ".join(claude_cmd)
+            cmd_str = f"{env_prefix} {' '.join(claude_cmd)}"
 
         # Send command to window to start interactive Claude
         if not self.tmux.send_keys(window_index, cmd_str, enter=True):

--- a/src/overcode/time_context.py
+++ b/src/overcode/time_context.py
@@ -1,0 +1,305 @@
+"""
+Time context generation for Claude Code hook integration.
+
+Outputs a compact time-awareness line injected into every prompt via
+a UserPromptSubmit hook, giving Claude continuous temporal context.
+
+Example output:
+    Clock: 14:32 PST | User: active | Office: yes | Uptime: 1h23m | Heartbeat: 15m (next: 7m)
+
+All functions are pure (no Rich/Typer dependencies) for easy testing.
+"""
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+def get_agent_identity() -> Tuple[Optional[str], Optional[str]]:
+    """Get session name and tmux session from environment variables.
+
+    Returns:
+        (session_name, tmux_session) tuple, either may be None
+    """
+    name = os.environ.get("OVERCODE_SESSION_NAME")
+    tmux = os.environ.get("OVERCODE_TMUX_SESSION")
+    return name, tmux
+
+
+def format_clock(now: datetime) -> str:
+    """Format current time as 'HH:MM TZ'.
+
+    Args:
+        now: Current datetime (should be timezone-aware)
+
+    Returns:
+        e.g. '14:32 PST'
+    """
+    tz_abbr = now.strftime("%Z") or "UTC"
+    return f"{now.strftime('%H:%M')} {tz_abbr}"
+
+
+def format_presence(presence_state: Optional[int]) -> str:
+    """Format user presence state from monitor daemon.
+
+    Args:
+        presence_state: 1=locked/sleep, 2=inactive, 3=active, None=unknown
+
+    Returns:
+        One of: 'active', 'inactive', 'locked', 'unknown'
+    """
+    mapping = {1: "locked", 2: "inactive", 3: "active"}
+    return mapping.get(presence_state, "unknown")
+
+
+def format_office_hours(now: datetime, start: int, end: int) -> str:
+    """Check if current hour is within office hours.
+
+    Supports midnight wrap (e.g. start=22, end=6 means 22:00-06:00).
+
+    Args:
+        now: Current datetime
+        start: Office start hour (0-23)
+        end: Office end hour (0-23)
+
+    Returns:
+        'yes' or 'no'
+    """
+    hour = now.hour
+    if start <= end:
+        # Normal range (e.g. 9-17)
+        return "yes" if start <= hour < end else "no"
+    else:
+        # Midnight wrap (e.g. 22-6)
+        return "yes" if hour >= start or hour < end else "no"
+
+
+def format_uptime(start_iso: Optional[str], now: datetime) -> Optional[str]:
+    """Format session uptime as compact duration.
+
+    Args:
+        start_iso: ISO timestamp of session start, or None
+        now: Current datetime
+
+    Returns:
+        e.g. '1h23m', '45m', '2h0m', or None if start_iso is None
+    """
+    if not start_iso:
+        return None
+
+    try:
+        start = datetime.fromisoformat(start_iso)
+        # Make both naive for comparison if needed
+        if start.tzinfo and not now.tzinfo:
+            start = start.replace(tzinfo=None)
+        elif now.tzinfo and not start.tzinfo:
+            start = start.replace(tzinfo=now.tzinfo)
+
+        seconds = (now - start).total_seconds()
+        if seconds < 0:
+            return "0m"
+        hours = int(seconds // 3600)
+        minutes = int((seconds % 3600) // 60)
+        if hours > 0:
+            return f"{hours}h{minutes}m"
+        return f"{minutes}m"
+    except (ValueError, TypeError):
+        return None
+
+
+def format_heartbeat(
+    interval_minutes: Optional[int],
+    last_iso: Optional[str],
+    now: datetime,
+) -> Optional[str]:
+    """Format heartbeat status.
+
+    Args:
+        interval_minutes: Heartbeat interval in minutes, or None if disabled
+        last_iso: ISO timestamp of last heartbeat, or None
+        now: Current datetime
+
+    Returns:
+        e.g. '15m (next: 7m)', '15m (next: now)', or None if disabled
+    """
+    if not interval_minutes:
+        return None
+
+    if not last_iso:
+        return f"{interval_minutes}m (next: now)"
+
+    try:
+        last = datetime.fromisoformat(last_iso)
+        if last.tzinfo and not now.tzinfo:
+            last = last.replace(tzinfo=None)
+        elif now.tzinfo and not last.tzinfo:
+            last = last.replace(tzinfo=now.tzinfo)
+
+        elapsed = (now - last).total_seconds()
+        remaining = (interval_minutes * 60) - elapsed
+
+        if remaining <= 0:
+            return f"{interval_minutes}m (next: now)"
+
+        remaining_min = int(remaining // 60)
+        return f"{interval_minutes}m (next: {remaining_min}m)"
+    except (ValueError, TypeError):
+        return f"{interval_minutes}m (next: now)"
+
+
+def read_heartbeat_timestamp(tmux_session: str, session_name: str) -> Optional[str]:
+    """Read last heartbeat timestamp from file.
+
+    Args:
+        tmux_session: Tmux session name
+        session_name: Agent session name
+
+    Returns:
+        ISO timestamp string, or None if file doesn't exist
+    """
+    path = (
+        Path.home()
+        / ".overcode"
+        / "sessions"
+        / tmux_session
+        / f"heartbeat_{session_name}.last"
+    )
+    try:
+        return path.read_text().strip()
+    except (FileNotFoundError, IOError):
+        return None
+
+
+def build_time_context_line(
+    clock: str,
+    presence: str,
+    office: str,
+    uptime: Optional[str] = None,
+    heartbeat: Optional[str] = None,
+) -> str:
+    """Assemble the final time context line.
+
+    Omits fields that are None.
+
+    Args:
+        clock: Formatted clock string
+        presence: Formatted presence string
+        office: Formatted office hours string
+        uptime: Formatted uptime string, or None to omit
+        heartbeat: Formatted heartbeat string, or None to omit
+
+    Returns:
+        Single-line string like 'Clock: 14:32 PST | User: active | Office: yes | Uptime: 1h23m'
+    """
+    parts = [
+        f"Clock: {clock}",
+        f"User: {presence}",
+        f"Office: {office}",
+    ]
+    if uptime is not None:
+        parts.append(f"Uptime: {uptime}")
+    if heartbeat is not None:
+        parts.append(f"Heartbeat: {heartbeat}")
+    return " | ".join(parts)
+
+
+def _load_daemon_state(tmux_session: str) -> Optional[dict]:
+    """Load monitor daemon state JSON.
+
+    Args:
+        tmux_session: Tmux session name
+
+    Returns:
+        Parsed dict, or None if unavailable
+    """
+    state_path = (
+        Path.home()
+        / ".overcode"
+        / "sessions"
+        / tmux_session
+        / "monitor_daemon_state.json"
+    )
+    # Also respect OVERCODE_STATE_DIR for testing
+    state_dir = os.environ.get("OVERCODE_STATE_DIR")
+    if state_dir:
+        state_path = Path(state_dir) / tmux_session / "monitor_daemon_state.json"
+
+    try:
+        with open(state_path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, IOError):
+        return None
+
+
+def _find_session_in_state(state: dict, session_name: str) -> Optional[dict]:
+    """Find a session by name in daemon state.
+
+    Args:
+        state: Parsed daemon state dict
+        session_name: Agent session name
+
+    Returns:
+        Session dict, or None
+    """
+    for s in state.get("sessions", []):
+        if s.get("name") == session_name:
+            return s
+    return None
+
+
+def generate_time_context(
+    tmux_session: str,
+    session_name: str,
+    now: Optional[datetime] = None,
+    config: Optional[dict] = None,
+) -> str:
+    """Orchestrator: reads state, config, calls formatters, returns final line.
+
+    Args:
+        tmux_session: Tmux session name
+        session_name: Agent session name
+        now: Current datetime (defaults to now with local timezone)
+        config: Time context config dict (defaults to loading from config.yaml)
+
+    Returns:
+        Complete time context line
+    """
+    if now is None:
+        now = datetime.now().astimezone()
+
+    if config is None:
+        from .config import get_time_context_config
+        config = get_time_context_config()
+
+    # Clock
+    clock = format_clock(now)
+
+    # Presence from daemon state
+    state = _load_daemon_state(tmux_session)
+    presence_state = None
+    start_time = None
+
+    if state:
+        presence_state = state.get("presence_state")
+        session_data = _find_session_in_state(state, session_name)
+        if session_data:
+            start_time = session_data.get("start_time")
+
+    presence = format_presence(presence_state)
+
+    # Office hours
+    office_start = config.get("office_start", 9)
+    office_end = config.get("office_end", 17)
+    office = format_office_hours(now, office_start, office_end)
+
+    # Uptime
+    uptime = format_uptime(start_time, now)
+
+    # Heartbeat
+    interval = config.get("heartbeat_interval_minutes")
+    last_heartbeat = read_heartbeat_timestamp(tmux_session, session_name)
+    heartbeat = format_heartbeat(interval, last_heartbeat, now)
+
+    return build_time_context_line(clock, presence, office, uptime, heartbeat)

--- a/tests/unit/test_time_context.py
+++ b/tests/unit/test_time_context.py
@@ -1,0 +1,436 @@
+"""
+Unit tests for time_context module.
+"""
+
+import json
+import pytest
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from overcode.time_context import (
+    get_agent_identity,
+    format_clock,
+    format_presence,
+    format_office_hours,
+    format_uptime,
+    format_heartbeat,
+    read_heartbeat_timestamp,
+    build_time_context_line,
+    generate_time_context,
+)
+
+
+class TestGetAgentIdentity:
+    """Test environment variable reading."""
+
+    def test_returns_both_when_set(self, monkeypatch):
+        monkeypatch.setenv("OVERCODE_SESSION_NAME", "my-agent")
+        monkeypatch.setenv("OVERCODE_TMUX_SESSION", "agents")
+        name, tmux = get_agent_identity()
+        assert name == "my-agent"
+        assert tmux == "agents"
+
+    def test_returns_none_when_missing(self, monkeypatch):
+        monkeypatch.delenv("OVERCODE_SESSION_NAME", raising=False)
+        monkeypatch.delenv("OVERCODE_TMUX_SESSION", raising=False)
+        name, tmux = get_agent_identity()
+        assert name is None
+        assert tmux is None
+
+    def test_returns_partial(self, monkeypatch):
+        monkeypatch.setenv("OVERCODE_SESSION_NAME", "test")
+        monkeypatch.delenv("OVERCODE_TMUX_SESSION", raising=False)
+        name, tmux = get_agent_identity()
+        assert name == "test"
+        assert tmux is None
+
+
+class TestFormatClock:
+    """Test clock formatting."""
+
+    def test_basic_format(self):
+        # Use a timezone-aware datetime
+        pst = timezone(timedelta(hours=-8))
+        now = datetime(2025, 1, 15, 14, 32, 0, tzinfo=pst)
+        result = format_clock(now)
+        assert result.startswith("14:32")
+
+    def test_leading_zero_hours(self):
+        pst = timezone(timedelta(hours=-8))
+        now = datetime(2025, 1, 15, 9, 5, 0, tzinfo=pst)
+        result = format_clock(now)
+        assert result.startswith("09:05")
+
+    def test_midnight(self):
+        utc = timezone.utc
+        now = datetime(2025, 1, 15, 0, 0, 0, tzinfo=utc)
+        result = format_clock(now)
+        assert result.startswith("00:00")
+
+
+class TestFormatPresence:
+    """Test presence state formatting."""
+
+    def test_active(self):
+        assert format_presence(3) == "active"
+
+    def test_inactive(self):
+        assert format_presence(2) == "inactive"
+
+    def test_locked(self):
+        assert format_presence(1) == "locked"
+
+    def test_none(self):
+        assert format_presence(None) == "unknown"
+
+    def test_invalid_value(self):
+        assert format_presence(99) == "unknown"
+
+
+class TestFormatOfficeHours:
+    """Test office hours calculation."""
+
+    def test_within_normal_hours(self):
+        now = datetime(2025, 1, 15, 10, 0)
+        assert format_office_hours(now, 9, 17) == "yes"
+
+    def test_before_normal_hours(self):
+        now = datetime(2025, 1, 15, 7, 0)
+        assert format_office_hours(now, 9, 17) == "no"
+
+    def test_after_normal_hours(self):
+        now = datetime(2025, 1, 15, 18, 0)
+        assert format_office_hours(now, 9, 17) == "no"
+
+    def test_at_start_boundary(self):
+        now = datetime(2025, 1, 15, 9, 0)
+        assert format_office_hours(now, 9, 17) == "yes"
+
+    def test_at_end_boundary(self):
+        # End hour is exclusive (17:00 is not in 9-17)
+        now = datetime(2025, 1, 15, 17, 0)
+        assert format_office_hours(now, 9, 17) == "no"
+
+    def test_midnight_wrap_during_night(self):
+        # 22:00-06:00 range, currently 23:00
+        now = datetime(2025, 1, 15, 23, 0)
+        assert format_office_hours(now, 22, 6) == "yes"
+
+    def test_midnight_wrap_early_morning(self):
+        # 22:00-06:00 range, currently 03:00
+        now = datetime(2025, 1, 15, 3, 0)
+        assert format_office_hours(now, 22, 6) == "yes"
+
+    def test_midnight_wrap_outside(self):
+        # 22:00-06:00 range, currently 12:00
+        now = datetime(2025, 1, 15, 12, 0)
+        assert format_office_hours(now, 22, 6) == "no"
+
+
+class TestFormatUptime:
+    """Test uptime formatting."""
+
+    def test_hours_and_minutes(self):
+        now = datetime(2025, 1, 15, 15, 23, 0)
+        start = "2025-01-15T14:00:00"
+        result = format_uptime(start, now)
+        assert result == "1h23m"
+
+    def test_minutes_only(self):
+        now = datetime(2025, 1, 15, 14, 45, 0)
+        start = "2025-01-15T14:00:00"
+        result = format_uptime(start, now)
+        assert result == "45m"
+
+    def test_zero_minutes(self):
+        now = datetime(2025, 1, 15, 16, 0, 30)
+        start = "2025-01-15T14:00:00"
+        result = format_uptime(start, now)
+        assert result == "2h0m"
+
+    def test_none_start(self):
+        now = datetime(2025, 1, 15, 14, 0)
+        assert format_uptime(None, now) is None
+
+    def test_empty_start(self):
+        now = datetime(2025, 1, 15, 14, 0)
+        assert format_uptime("", now) is None
+
+    def test_invalid_iso(self):
+        now = datetime(2025, 1, 15, 14, 0)
+        assert format_uptime("not-a-date", now) is None
+
+    def test_negative_uptime(self):
+        now = datetime(2025, 1, 15, 13, 0, 0)
+        start = "2025-01-15T14:00:00"
+        result = format_uptime(start, now)
+        assert result == "0m"
+
+
+class TestFormatHeartbeat:
+    """Test heartbeat formatting."""
+
+    def test_disabled(self):
+        now = datetime(2025, 1, 15, 14, 0)
+        assert format_heartbeat(None, None, now) is None
+
+    def test_zero_interval(self):
+        now = datetime(2025, 1, 15, 14, 0)
+        assert format_heartbeat(0, None, now) is None
+
+    def test_no_last_timestamp(self):
+        now = datetime(2025, 1, 15, 14, 0)
+        result = format_heartbeat(15, None, now)
+        assert result == "15m (next: now)"
+
+    def test_overdue(self):
+        now = datetime(2025, 1, 15, 14, 30, 0)
+        last = "2025-01-15T14:00:00"
+        result = format_heartbeat(15, last, now)
+        assert result == "15m (next: now)"
+
+    def test_remaining_time(self):
+        now = datetime(2025, 1, 15, 14, 8, 0)
+        last = "2025-01-15T14:00:00"
+        result = format_heartbeat(15, last, now)
+        assert result == "15m (next: 7m)"
+
+    def test_invalid_last_timestamp(self):
+        now = datetime(2025, 1, 15, 14, 0)
+        result = format_heartbeat(15, "bad-date", now)
+        assert result == "15m (next: now)"
+
+
+class TestReadHeartbeatTimestamp:
+    """Test heartbeat file reading."""
+
+    def test_reads_existing_file(self, tmp_path, monkeypatch):
+        # Create the file structure
+        hb_dir = tmp_path / ".overcode" / "sessions" / "agents"
+        hb_dir.mkdir(parents=True)
+        hb_file = hb_dir / "heartbeat_my-agent.last"
+        hb_file.write_text("2025-01-15T14:00:00\n")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = read_heartbeat_timestamp("agents", "my-agent")
+        assert result == "2025-01-15T14:00:00"
+
+    def test_returns_none_for_missing_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = read_heartbeat_timestamp("agents", "nonexistent")
+        assert result is None
+
+
+class TestBuildTimeContextLine:
+    """Test line assembly."""
+
+    def test_all_fields(self):
+        result = build_time_context_line(
+            clock="14:32 PST",
+            presence="active",
+            office="yes",
+            uptime="1h23m",
+            heartbeat="15m (next: 7m)",
+        )
+        assert result == "Clock: 14:32 PST | User: active | Office: yes | Uptime: 1h23m | Heartbeat: 15m (next: 7m)"
+
+    def test_minimal_fields(self):
+        result = build_time_context_line(
+            clock="14:32 PST",
+            presence="unknown",
+            office="no",
+        )
+        assert result == "Clock: 14:32 PST | User: unknown | Office: no"
+        assert "Uptime" not in result
+        assert "Heartbeat" not in result
+
+    def test_uptime_only(self):
+        result = build_time_context_line(
+            clock="09:00 EST",
+            presence="active",
+            office="yes",
+            uptime="45m",
+        )
+        assert "Uptime: 45m" in result
+        assert "Heartbeat" not in result
+
+    def test_heartbeat_only(self):
+        result = build_time_context_line(
+            clock="09:00 EST",
+            presence="active",
+            office="yes",
+            heartbeat="15m (next: now)",
+        )
+        assert "Heartbeat: 15m (next: now)" in result
+        assert "Uptime" not in result
+
+
+class TestGenerateTimeContext:
+    """Integration test for the orchestrator."""
+
+    def test_full_output_with_daemon_state(self, tmp_path, monkeypatch):
+        """Test with mocked daemon state and config."""
+        # Set up state dir
+        state_dir = tmp_path / "state"
+        session_dir = state_dir / "agents"
+        session_dir.mkdir(parents=True)
+
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(state_dir))
+
+        # Write daemon state
+        daemon_state = {
+            "presence_state": 3,
+            "sessions": [
+                {
+                    "name": "my-agent",
+                    "start_time": "2025-01-15T13:00:00",
+                }
+            ],
+        }
+        state_file = session_dir / "monitor_daemon_state.json"
+        state_file.write_text(json.dumps(daemon_state))
+
+        config = {
+            "office_start": 9,
+            "office_end": 17,
+            "heartbeat_interval_minutes": None,
+        }
+
+        now = datetime(2025, 1, 15, 14, 32, 0)
+        result = generate_time_context("agents", "my-agent", now=now, config=config)
+
+        assert "Clock: 14:32" in result
+        assert "User: active" in result
+        assert "Office: yes" in result
+        assert "Uptime: 1h32m" in result
+        assert "Heartbeat" not in result
+
+    def test_no_daemon_state(self, tmp_path, monkeypatch):
+        """Test graceful degradation when daemon state is missing."""
+        state_dir = tmp_path / "state"
+        session_dir = state_dir / "agents"
+        session_dir.mkdir(parents=True)
+
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(state_dir))
+
+        config = {
+            "office_start": 9,
+            "office_end": 17,
+            "heartbeat_interval_minutes": None,
+        }
+
+        now = datetime(2025, 1, 15, 14, 0, 0)
+        result = generate_time_context("agents", "my-agent", now=now, config=config)
+
+        assert "User: unknown" in result
+        assert "Uptime" not in result
+
+    def test_session_not_in_daemon_state(self, tmp_path, monkeypatch):
+        """Test when session exists in daemon but our agent isn't tracked."""
+        state_dir = tmp_path / "state"
+        session_dir = state_dir / "agents"
+        session_dir.mkdir(parents=True)
+
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(state_dir))
+
+        daemon_state = {
+            "presence_state": 2,
+            "sessions": [
+                {"name": "other-agent", "start_time": "2025-01-15T10:00:00"}
+            ],
+        }
+        state_file = session_dir / "monitor_daemon_state.json"
+        state_file.write_text(json.dumps(daemon_state))
+
+        config = {
+            "office_start": 9,
+            "office_end": 17,
+            "heartbeat_interval_minutes": None,
+        }
+
+        now = datetime(2025, 1, 15, 14, 0, 0)
+        result = generate_time_context("agents", "my-agent", now=now, config=config)
+
+        assert "User: inactive" in result
+        assert "Uptime" not in result
+
+    def test_with_heartbeat(self, tmp_path, monkeypatch):
+        """Test heartbeat field when configured."""
+        state_dir = tmp_path / "state"
+        session_dir = state_dir / "agents"
+        session_dir.mkdir(parents=True)
+
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(state_dir))
+
+        # Write daemon state
+        state_file = session_dir / "monitor_daemon_state.json"
+        state_file.write_text(json.dumps({"sessions": []}))
+
+        # Write heartbeat file
+        hb_dir = tmp_path / ".overcode" / "sessions" / "agents"
+        hb_dir.mkdir(parents=True)
+        hb_file = hb_dir / "heartbeat_my-agent.last"
+        hb_file.write_text("2025-01-15T14:00:00")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        config = {
+            "office_start": 9,
+            "office_end": 17,
+            "heartbeat_interval_minutes": 15,
+        }
+
+        now = datetime(2025, 1, 15, 14, 8, 0)
+        result = generate_time_context("agents", "my-agent", now=now, config=config)
+
+        assert "Heartbeat: 15m (next: 7m)" in result
+
+
+class TestCliSilentExit:
+    """Test CLI silent exit when env vars are missing."""
+
+    def test_silent_exit_no_env_vars(self, monkeypatch):
+        """time-context command should exit silently when env vars missing."""
+        from typer.testing import CliRunner
+        from overcode.cli import app
+
+        monkeypatch.delenv("OVERCODE_SESSION_NAME", raising=False)
+        monkeypatch.delenv("OVERCODE_TMUX_SESSION", raising=False)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["time-context"])
+
+        assert result.exit_code == 0
+        assert result.output.strip() == ""
+
+    def test_outputs_line_with_env_vars(self, tmp_path, monkeypatch):
+        """time-context command should output a line when env vars are set."""
+        from typer.testing import CliRunner
+        from overcode.cli import app
+
+        monkeypatch.setenv("OVERCODE_SESSION_NAME", "test-agent")
+        monkeypatch.setenv("OVERCODE_TMUX_SESSION", "agents")
+
+        # Set up empty state dir so daemon state is missing (graceful degradation)
+        state_dir = tmp_path / "state"
+        session_dir = state_dir / "agents"
+        session_dir.mkdir(parents=True)
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(state_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["time-context"])
+
+        assert result.exit_code == 0
+        output = result.output.strip()
+        assert "Clock:" in output
+        assert "User:" in output
+        assert "Office:" in output
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Adds `overcode time-context` CLI command that outputs a compact time-awareness line (clock, user presence, office hours, uptime, heartbeat) for injection into Claude prompts via a `UserPromptSubmit` hook (#172)
- Sets `OVERCODE_SESSION_NAME` and `OVERCODE_TMUX_SESSION` env vars on agent launch so each agent knows its identity
- Silently exits with no output when not in an overcode-managed session (env vars missing)

## Test plan
- [x] `uv run pytest tests/unit/test_time_context.py -v` — 44 new tests pass
- [x] `uv run pytest tests/unit/ -v` — full suite passes, no regressions
- [ ] Manual: `OVERCODE_SESSION_NAME=test OVERCODE_TMUX_SESSION=agents overcode time-context` — outputs formatted line
- [ ] Manual: `overcode time-context` (no env vars) — silent exit
- [ ] Manual: Launch agent with `overcode launch`, verify env vars set in tmux pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)