### PR TITLE
Add fullscreen scrollable preview viewer (#190)

### DIFF
--- a/src/overcode/tui.tcss
+++ b/src/overcode/tui.tcss
@@ -109,6 +109,21 @@ SessionSummary.terminated:focus {
     display: block;
 }
 
+#fullscreen-preview {
+    display: none;
+    layer: above;
+    dock: top;
+    width: 100%;
+    height: 100%;
+    background: $surface 90%;
+    padding: 1 2;
+    overflow-y: auto;
+}
+
+#fullscreen-preview.visible {
+    display: block;
+}
+
 #daemon-panel {
     display: none;
     height: auto;

--- a/src/overcode/tui_widgets/__init__.py
+++ b/src/overcode/tui_widgets/__init__.py
@@ -5,6 +5,7 @@ This package contains the individual widget classes extracted from tui.py
 for better maintainability and testability.
 """
 
+from .fullscreen_preview import FullscreenPreview
 from .help_overlay import HelpOverlay
 from .preview_pane import PreviewPane
 from .daemon_panel import DaemonPanel
@@ -15,6 +16,7 @@ from .command_bar import CommandBar
 from .summary_config_modal import SummaryConfigModal
 
 __all__ = [
+    "FullscreenPreview",
     "HelpOverlay",
     "PreviewPane",
     "DaemonPanel",

--- a/src/overcode/tui_widgets/fullscreen_preview.py
+++ b/src/overcode/tui_widgets/fullscreen_preview.py
@@ -1,0 +1,71 @@
+"""
+Fullscreen preview overlay widget for TUI.
+
+Displays a scrollable fullscreen view of an agent's terminal output
+with up to 500 lines of scrollback history.
+"""
+
+from typing import List
+
+from textual.widgets import Static
+from textual import events
+from rich.text import Text
+from rich.panel import Panel
+from rich import box
+
+
+class FullscreenPreview(Static, can_focus=True):
+    """Fullscreen scrollable preview of an agent's terminal output."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._content_lines: List[str] = []
+        self._session_name: str = ""
+        self._monochrome: bool = False
+
+    def render(self) -> Panel:
+        content = Text()
+
+        if not self._content_lines:
+            content.append("(no output)", style="dim italic")
+        else:
+            pane_width = self.size.width - 6 if self.size.width > 6 else 80
+            max_line_len = max(pane_width, 40)
+            for line in self._content_lines:
+                display_line = line[:max_line_len] if len(line) > max_line_len else line
+                if self._monochrome:
+                    parsed = Text.from_ansi(display_line)
+                    content.append(parsed.plain)
+                else:
+                    content.append(Text.from_ansi(display_line))
+                content.append("\n")
+
+        title = Text()
+        title.append(f" {self._session_name} ", style="bold bright_white")
+
+        return Panel(
+            content,
+            title=title,
+            subtitle=Text("Press Esc/f/q to close", style="dim"),
+            border_style="bright_cyan",
+            box=box.DOUBLE,
+        )
+
+    def show(self, lines: List[str], session_name: str, monochrome: bool) -> None:
+        """Show the fullscreen preview with the given content."""
+        self._content_lines = lines
+        self._session_name = session_name
+        self._monochrome = monochrome
+        self.add_class("visible")
+        self.refresh()
+        self.focus()
+
+    def hide(self) -> None:
+        """Hide the fullscreen preview."""
+        self.remove_class("visible")
+
+    def on_key(self, event: events.Key) -> None:
+        """Handle keyboard input — Esc/f/q close the overlay."""
+        if event.key in ("escape", "f", "q"):
+            self.hide()
+            event.stop()

--- a/src/overcode/tui_widgets/help_overlay.py
+++ b/src/overcode/tui_widgets/help_overlay.py
@@ -35,8 +35,8 @@ class HelpOverlay(Static):
         row("j/↓", "Next agent", "k/↑", "Previous agent")
         row("space", "Toggle expand", "m", "Toggle tree/list")
         row("e", "Expand/Collapse all", "c", "Sync main + clear")
-        row("h/?", "Toggle help", "r", "Refresh")
-        row("q", "Quit")
+        row("f", "Fullscreen preview", "r", "Refresh")
+        row("h/?", "Toggle help", "q", "Quit")
         t.append("\n")
 
         section("DISPLAY MODES")


### PR DESCRIPTION
## Summary
- Adds `f` hotkey in list+preview mode to open a fullscreen scrollable overlay with 500 lines of tmux scrollback
- Follows the existing HelpOverlay pattern: `Static` on `layer: above`, toggled with `.visible` CSS class
- Blocks other keybindings while overlay is open; closes with `Esc`/`f`/`q`

## Test plan
- [ ] Press `m` to enter list+preview mode, focus an agent with `j`/`k`, press `f` — fullscreen overlay appears
- [ ] Scroll with arrow keys, Page Up/Down, mouse wheel
- [ ] Press `Esc`, `f`, or `q` to close
- [ ] Verify other keys are blocked while overlay is open
- [ ] Press `h` and confirm help text shows the `f` key
- [ ] Press `f` outside list+preview mode — should show notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)