### PR TITLE
Add 225 unit tests, coverage 54% → 61%

### DIFF
--- a/tests/unit/test_monitor_daemon.py
+++ b/tests/unit/test_monitor_daemon.py
@@ -306,6 +306,770 @@ class TestMonitorDaemonState:
         assert state.is_stale() is False
 
 
+class TestCreateMonitorLogger:
+    """Test _create_monitor_logger factory function."""
+
+    def test_returns_base_daemon_logger_instance(self, tmp_path):
+        """Should return a BaseDaemonLogger instance."""
+        from overcode.monitor_daemon import _create_monitor_logger
+        from overcode.daemon_logging import BaseDaemonLogger
+
+        log_file = tmp_path / "test.log"
+        logger = _create_monitor_logger(session="test", log_file=log_file)
+
+        assert isinstance(logger, BaseDaemonLogger)
+        assert logger.log_file == log_file
+
+    def test_creates_default_log_file_path(self, tmp_path, monkeypatch):
+        """Should create logger with default session-specific log path."""
+        from overcode.monitor_daemon import _create_monitor_logger
+        from overcode.daemon_logging import BaseDaemonLogger
+
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.ensure_session_dir',
+            lambda x: tmp_path
+        )
+
+        logger = _create_monitor_logger(session="test")
+
+        assert isinstance(logger, BaseDaemonLogger)
+        assert logger.log_file == tmp_path / "monitor_daemon.log"
+
+
+class TestSyncClaudeCodeStats:
+    """Test sync_claude_code_stats method."""
+
+    def _make_daemon(self, tmp_path, monkeypatch):
+        """Helper to create a minimal MonitorDaemon for testing."""
+        from overcode.monitor_daemon import MonitorDaemon
+
+        monkeypatch.setattr('overcode.monitor_daemon.ensure_session_dir', lambda x: tmp_path)
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_monitor_daemon_pid_path',
+            lambda x: tmp_path / "pid"
+        )
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_monitor_daemon_state_path',
+            lambda x: tmp_path / "state.json"
+        )
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_agent_history_path',
+            lambda x: tmp_path / "history.csv"
+        )
+
+        with patch('overcode.monitor_daemon.SessionManager') as mock_sm_cls:
+            with patch('overcode.monitor_daemon.StatusDetector'):
+                daemon = MonitorDaemon(tmux_session="test")
+                daemon.session_manager = mock_sm_cls.return_value
+        return daemon
+
+    def test_updates_stats_when_session_stats_available(self, tmp_path, monkeypatch):
+        """Should call update_stats with token and cost data from Claude history."""
+        from overcode.monitor_daemon import MonitorDaemon
+        from unittest.mock import MagicMock
+
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+
+        mock_session = Mock()
+        mock_session.id = "sess-1"
+        mock_session.name = "agent-1"
+        mock_session.start_directory = "/tmp/project"
+        mock_session.start_time = datetime.now().isoformat()
+
+        mock_stats = Mock()
+        mock_stats.interaction_count = 10
+        mock_stats.input_tokens = 5000
+        mock_stats.output_tokens = 2000
+        mock_stats.cache_creation_tokens = 100
+        mock_stats.cache_read_tokens = 50
+
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_session_stats',
+            lambda s: mock_stats
+        )
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_current_session_id_for_directory',
+            lambda d, s: "claude-sess-abc"
+        )
+
+        # Mock get_user_config - it's imported lazily inside sync_claude_code_stats
+        mock_config = Mock()
+        mock_config.price_input = 15.0
+        mock_config.price_output = 75.0
+        mock_config.price_cache_write = 18.75
+        mock_config.price_cache_read = 1.50
+        monkeypatch.setattr(
+            'overcode.settings.get_user_config',
+            lambda: mock_config
+        )
+
+        daemon.sync_claude_code_stats(mock_session)
+
+        # Verify add_claude_session_id was called
+        daemon.session_manager.add_claude_session_id.assert_called_once_with(
+            "sess-1", "claude-sess-abc"
+        )
+
+        # Verify update_stats was called with correct values
+        daemon.session_manager.update_stats.assert_called_once()
+        call_kwargs = daemon.session_manager.update_stats.call_args[1]
+        assert call_kwargs["interaction_count"] == 10
+        assert call_kwargs["input_tokens"] == 5000
+        assert call_kwargs["output_tokens"] == 2000
+        assert call_kwargs["cache_creation_tokens"] == 100
+        assert call_kwargs["cache_read_tokens"] == 50
+        assert call_kwargs["total_tokens"] == 7150  # 5000+2000+100+50
+
+    def test_returns_early_when_stats_are_none(self, tmp_path, monkeypatch):
+        """Should return early when get_session_stats returns None."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+
+        mock_session = Mock()
+        mock_session.id = "sess-1"
+        mock_session.name = "agent-1"
+        mock_session.start_directory = "/tmp/project"
+        mock_session.start_time = datetime.now().isoformat()
+
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_session_stats',
+            lambda s: None
+        )
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_current_session_id_for_directory',
+            lambda d, s: None
+        )
+
+        daemon.sync_claude_code_stats(mock_session)
+
+        # update_stats should not be called when stats are None
+        daemon.session_manager.update_stats.assert_not_called()
+
+    def test_handles_exception_gracefully(self, tmp_path, monkeypatch):
+        """Should log warning and not raise on exception."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+
+        mock_session = Mock()
+        mock_session.id = "sess-1"
+        mock_session.name = "agent-1"
+        mock_session.start_directory = "/tmp/project"
+        mock_session.start_time = datetime.now().isoformat()
+
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_session_stats',
+            Mock(side_effect=RuntimeError("disk failure"))
+        )
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_current_session_id_for_directory',
+            lambda d, s: None
+        )
+
+        # Should not raise
+        daemon.sync_claude_code_stats(mock_session)
+
+    def test_skips_session_id_capture_without_start_directory(self, tmp_path, monkeypatch):
+        """Should skip add_claude_session_id when session has no start_directory."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+
+        mock_session = Mock()
+        mock_session.id = "sess-1"
+        mock_session.name = "agent-1"
+        mock_session.start_directory = None  # No start dir
+        mock_session.start_time = datetime.now().isoformat()
+
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_session_stats',
+            lambda s: None
+        )
+
+        daemon.sync_claude_code_stats(mock_session)
+
+        # add_claude_session_id should not be called
+        daemon.session_manager.add_claude_session_id.assert_not_called()
+
+
+class TestUpdateStateTime:
+    """Test _update_state_time method."""
+
+    def _make_daemon(self, tmp_path, monkeypatch):
+        """Helper to create a minimal MonitorDaemon for testing."""
+        from overcode.monitor_daemon import MonitorDaemon
+
+        monkeypatch.setattr('overcode.monitor_daemon.ensure_session_dir', lambda x: tmp_path)
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_monitor_daemon_pid_path',
+            lambda x: tmp_path / "pid"
+        )
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_monitor_daemon_state_path',
+            lambda x: tmp_path / "state.json"
+        )
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_agent_history_path',
+            lambda x: tmp_path / "history.csv"
+        )
+
+        with patch('overcode.monitor_daemon.SessionManager') as mock_sm_cls:
+            with patch('overcode.monitor_daemon.StatusDetector'):
+                daemon = MonitorDaemon(tmux_session="test")
+                daemon.session_manager = mock_sm_cls.return_value
+        return daemon
+
+    def _make_session(self, session_id="sess-1", green_time=0.0, non_green_time=0.0,
+                      sleep_time=0.0, state_since=None, last_time_accumulation=None,
+                      start_time=None):
+        """Helper to create a mock session."""
+        mock_session = Mock()
+        mock_session.id = session_id
+        mock_session.name = "agent-1"
+        mock_session.start_time = start_time or datetime.now().isoformat()
+
+        mock_stats = Mock()
+        mock_stats.green_time_seconds = green_time
+        mock_stats.non_green_time_seconds = non_green_time
+        mock_stats.sleep_time_seconds = sleep_time
+        mock_stats.state_since = state_since or datetime.now().isoformat()
+        mock_stats.last_time_accumulation = last_time_accumulation
+        mock_session.stats = mock_stats
+
+        return mock_session
+
+    def test_first_observation_does_not_accumulate(self, tmp_path, monkeypatch):
+        """First observation should set last_state_time but not accumulate."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+        session = self._make_session()
+        now = datetime.now()
+
+        daemon._update_state_time(session, "running", now)
+
+        # Should not call update_stats on first observation (just records baseline)
+        daemon.session_manager.update_stats.assert_not_called()
+        # last_state_times should now have an entry
+        assert session.id in daemon.last_state_times
+
+    def test_green_status_accumulates_green_time(self, tmp_path, monkeypatch):
+        """Green status should increase green_time_seconds."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+        session = self._make_session(
+            green_time=100.0,
+            non_green_time=50.0,
+            start_time=(datetime.now() - timedelta(hours=1)).isoformat()
+        )
+        now = datetime.now()
+
+        # Set up prior observation time (10 seconds ago)
+        daemon.last_state_times[session.id] = now - timedelta(seconds=10)
+
+        daemon._update_state_time(session, "running", now)
+
+        # update_stats should be called
+        daemon.session_manager.update_stats.assert_called_once()
+        call_kwargs = daemon.session_manager.update_stats.call_args[1]
+        # Green time should have increased by ~10 seconds
+        assert call_kwargs["green_time_seconds"] > 100.0
+
+    def test_non_green_status_accumulates_non_green_time(self, tmp_path, monkeypatch):
+        """Non-green status should increase non_green_time_seconds."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+        session = self._make_session(
+            green_time=100.0,
+            non_green_time=50.0,
+            start_time=(datetime.now() - timedelta(hours=1)).isoformat()
+        )
+        now = datetime.now()
+
+        daemon.last_state_times[session.id] = now - timedelta(seconds=10)
+
+        daemon._update_state_time(session, "waiting_user", now)
+
+        daemon.session_manager.update_stats.assert_called_once()
+        call_kwargs = daemon.session_manager.update_stats.call_args[1]
+        # Non-green time should have increased
+        assert call_kwargs["non_green_time_seconds"] > 50.0
+
+    def test_state_transition_detection(self, tmp_path, monkeypatch):
+        """State transition should update state_since."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+        session = self._make_session(
+            green_time=100.0,
+            non_green_time=50.0,
+            state_since=(datetime.now() - timedelta(minutes=5)).isoformat(),
+            start_time=(datetime.now() - timedelta(hours=1)).isoformat()
+        )
+        now = datetime.now()
+
+        daemon.last_state_times[session.id] = now - timedelta(seconds=10)
+        # Previous state was running, now waiting - state changed
+        daemon.previous_states[session.id] = "running"
+
+        daemon._update_state_time(session, "waiting_user", now)
+
+        daemon.session_manager.update_stats.assert_called_once()
+        call_kwargs = daemon.session_manager.update_stats.call_args[1]
+        assert call_kwargs["current_state"] == "waiting_user"
+        # state_since should be updated to now (state changed)
+        assert call_kwargs["state_since"] == now.isoformat()
+
+
+class TestCheckAndSendHeartbeats:
+    """Test check_and_send_heartbeats method."""
+
+    def _make_daemon(self, tmp_path, monkeypatch):
+        """Helper to create a minimal MonitorDaemon for testing."""
+        from overcode.monitor_daemon import MonitorDaemon
+
+        monkeypatch.setattr('overcode.monitor_daemon.ensure_session_dir', lambda x: tmp_path)
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_monitor_daemon_pid_path',
+            lambda x: tmp_path / "pid"
+        )
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_monitor_daemon_state_path',
+            lambda x: tmp_path / "state.json"
+        )
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_agent_history_path',
+            lambda x: tmp_path / "history.csv"
+        )
+
+        with patch('overcode.monitor_daemon.SessionManager') as mock_sm_cls:
+            with patch('overcode.monitor_daemon.StatusDetector'):
+                daemon = MonitorDaemon(tmux_session="test")
+                daemon.session_manager = mock_sm_cls.return_value
+        return daemon
+
+    def _make_heartbeat_session(self, session_id="sess-hb", enabled=True,
+                                 paused=False, is_asleep=False,
+                                 instruction="continue working",
+                                 frequency=300, last_heartbeat=None,
+                                 start_time=None, tmux_session="test",
+                                 tmux_window=1):
+        """Helper to create a mock session with heartbeat fields."""
+        mock = Mock()
+        mock.id = session_id
+        mock.name = "agent-hb"
+        mock.heartbeat_enabled = enabled
+        mock.heartbeat_paused = paused
+        mock.is_asleep = is_asleep
+        mock.heartbeat_instruction = instruction
+        mock.heartbeat_frequency_seconds = frequency
+        mock.last_heartbeat_time = last_heartbeat
+        mock.start_time = start_time or (datetime.now() - timedelta(hours=1)).isoformat()
+        mock.tmux_session = tmux_session
+        mock.tmux_window = tmux_window
+        return mock
+
+    def test_sends_heartbeat_when_due(self, tmp_path, monkeypatch):
+        """Should send heartbeat when frequency interval has elapsed."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+
+        # Last heartbeat was 10 minutes ago, frequency is 5 minutes
+        session = self._make_heartbeat_session(
+            frequency=300,
+            last_heartbeat=(datetime.now() - timedelta(minutes=10)).isoformat()
+        )
+
+        with patch('overcode.monitor_daemon.send_text_to_tmux_window', return_value=True) as mock_send:
+            result = daemon.check_and_send_heartbeats([session])
+
+        assert session.id in result
+        mock_send.assert_called_once_with(
+            "test", 1, "continue working", send_enter=True
+        )
+        daemon.session_manager.update_session.assert_called_once()
+
+    def test_does_not_send_heartbeat_when_not_due(self, tmp_path, monkeypatch):
+        """Should not send heartbeat when interval has not elapsed."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+
+        # Last heartbeat was 1 minute ago, frequency is 5 minutes
+        session = self._make_heartbeat_session(
+            frequency=300,
+            last_heartbeat=(datetime.now() - timedelta(minutes=1)).isoformat()
+        )
+
+        with patch('overcode.monitor_daemon.send_text_to_tmux_window') as mock_send:
+            result = daemon.check_and_send_heartbeats([session])
+
+        assert len(result) == 0
+        mock_send.assert_not_called()
+
+    def test_skips_paused_heartbeat(self, tmp_path, monkeypatch):
+        """Should skip sessions with heartbeat_paused=True."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+
+        session = self._make_heartbeat_session(
+            paused=True,
+            last_heartbeat=(datetime.now() - timedelta(hours=1)).isoformat()
+        )
+
+        with patch('overcode.monitor_daemon.send_text_to_tmux_window') as mock_send:
+            result = daemon.check_and_send_heartbeats([session])
+
+        assert len(result) == 0
+        mock_send.assert_not_called()
+
+    def test_skips_sleeping_session(self, tmp_path, monkeypatch):
+        """Should skip sessions that are asleep."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+
+        session = self._make_heartbeat_session(
+            is_asleep=True,
+            last_heartbeat=(datetime.now() - timedelta(hours=1)).isoformat()
+        )
+
+        with patch('overcode.monitor_daemon.send_text_to_tmux_window') as mock_send:
+            result = daemon.check_and_send_heartbeats([session])
+
+        assert len(result) == 0
+        mock_send.assert_not_called()
+
+    def test_skips_session_without_instruction(self, tmp_path, monkeypatch):
+        """Should skip sessions with no heartbeat_instruction."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+
+        session = self._make_heartbeat_session(
+            instruction="",
+            last_heartbeat=(datetime.now() - timedelta(hours=1)).isoformat()
+        )
+
+        with patch('overcode.monitor_daemon.send_text_to_tmux_window') as mock_send:
+            result = daemon.check_and_send_heartbeats([session])
+
+        assert len(result) == 0
+        mock_send.assert_not_called()
+
+    def test_skips_disabled_heartbeat(self, tmp_path, monkeypatch):
+        """Should skip sessions with heartbeat_enabled=False."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+
+        session = self._make_heartbeat_session(
+            enabled=False,
+            last_heartbeat=(datetime.now() - timedelta(hours=1)).isoformat()
+        )
+
+        with patch('overcode.monitor_daemon.send_text_to_tmux_window') as mock_send:
+            result = daemon.check_and_send_heartbeats([session])
+
+        assert len(result) == 0
+        mock_send.assert_not_called()
+
+    def test_uses_start_time_when_no_last_heartbeat(self, tmp_path, monkeypatch):
+        """Should fall back to session start_time when last_heartbeat_time is None."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+
+        # No last_heartbeat_time, but start_time is 10 minutes ago
+        session = self._make_heartbeat_session(
+            frequency=300,
+            last_heartbeat=None,
+            start_time=(datetime.now() - timedelta(minutes=10)).isoformat()
+        )
+
+        with patch('overcode.monitor_daemon.send_text_to_tmux_window', return_value=True) as mock_send:
+            result = daemon.check_and_send_heartbeats([session])
+
+        assert session.id in result
+        mock_send.assert_called_once()
+
+
+class TestInterruptibleSleep:
+    """Test _interruptible_sleep method."""
+
+    def _make_daemon(self, tmp_path, monkeypatch):
+        """Helper to create a minimal MonitorDaemon for testing."""
+        from overcode.monitor_daemon import MonitorDaemon
+
+        monkeypatch.setattr('overcode.monitor_daemon.ensure_session_dir', lambda x: tmp_path)
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_monitor_daemon_pid_path',
+            lambda x: tmp_path / "pid"
+        )
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_monitor_daemon_state_path',
+            lambda x: tmp_path / "state.json"
+        )
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_agent_history_path',
+            lambda x: tmp_path / "history.csv"
+        )
+
+        with patch('overcode.monitor_daemon.SessionManager') as mock_sm_cls:
+            with patch('overcode.monitor_daemon.StatusDetector'):
+                daemon = MonitorDaemon(tmux_session="test")
+                daemon.session_manager = mock_sm_cls.return_value
+        return daemon
+
+    def test_returns_immediately_when_shutdown_set(self, tmp_path, monkeypatch):
+        """Should return immediately if _shutdown is True."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+        daemon._shutdown = True
+
+        with patch('overcode.monitor_daemon.time.sleep') as mock_sleep:
+            daemon._interruptible_sleep(60)
+
+        # Should not sleep at all since shutdown was already set
+        mock_sleep.assert_not_called()
+
+    def test_wakes_on_activity_signal(self, tmp_path, monkeypatch):
+        """Should return early when activity signal is detected."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+
+        call_count = [0]
+
+        def mock_check_signal(session):
+            call_count[0] += 1
+            # Return True on first check (after first sleep chunk)
+            return True
+
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.check_activity_signal',
+            mock_check_signal
+        )
+
+        with patch('overcode.monitor_daemon.time.sleep'):
+            daemon._interruptible_sleep(60)
+
+        # Should have checked activity signal and returned early
+        assert call_count[0] >= 1
+
+    def test_sleeps_full_duration_without_signals(self, tmp_path, monkeypatch):
+        """Should sleep the full duration when no signals occur."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.check_activity_signal',
+            lambda session: False
+        )
+
+        sleep_calls = []
+
+        def track_sleep(seconds):
+            sleep_calls.append(seconds)
+
+        with patch('overcode.monitor_daemon.time.sleep', side_effect=track_sleep):
+            daemon._interruptible_sleep(30)
+
+        # Should have slept in 10-second chunks: 10 + 10 + 10 = 30
+        assert sum(sleep_calls) == 30
+
+
+class TestPublishState:
+    """Test _publish_state method."""
+
+    def _make_daemon(self, tmp_path, monkeypatch):
+        """Helper to create a minimal MonitorDaemon for testing."""
+        from overcode.monitor_daemon import MonitorDaemon
+
+        monkeypatch.setattr('overcode.monitor_daemon.ensure_session_dir', lambda x: tmp_path)
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_monitor_daemon_pid_path',
+            lambda x: tmp_path / "pid"
+        )
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_monitor_daemon_state_path',
+            lambda x: tmp_path / "state.json"
+        )
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_agent_history_path',
+            lambda x: tmp_path / "history.csv"
+        )
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_supervisor_stats_path',
+            lambda x: tmp_path / "supervisor_stats.json"
+        )
+
+        with patch('overcode.monitor_daemon.SessionManager') as mock_sm_cls:
+            with patch('overcode.monitor_daemon.StatusDetector'):
+                daemon = MonitorDaemon(tmux_session="test")
+                daemon.session_manager = mock_sm_cls.return_value
+        return daemon
+
+    def test_saves_state_to_file(self, tmp_path, monkeypatch):
+        """Should save MonitorDaemonState to the state JSON file."""
+        from overcode.monitor_daemon import SessionDaemonState
+
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+
+        session_state = SessionDaemonState(
+            session_id="sess-1",
+            name="agent-1",
+            current_status="running",
+            green_time_seconds=120.0,
+        )
+
+        daemon._publish_state([session_state])
+
+        state_path = tmp_path / "state.json"
+        assert state_path.exists()
+
+        with open(state_path) as f:
+            data = json.load(f)
+
+        assert len(data["sessions"]) == 1
+        assert data["sessions"][0]["session_id"] == "sess-1"
+        assert data["sessions"][0]["current_status"] == "running"
+        assert data["last_loop_time"] is not None
+
+    def test_reads_supervisor_stats_when_available(self, tmp_path, monkeypatch):
+        """Should read supervisor stats from file when it exists."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+
+        # Write supervisor stats file
+        supervisor_stats = {
+            "supervisor_launches": 5,
+            "supervisor_tokens": 10000,
+            "supervisor_claude_running": True,
+            "supervisor_claude_started_at": "2025-01-01T12:00:00",
+            "supervisor_claude_total_run_seconds": 300.0,
+        }
+        supervisor_path = tmp_path / "supervisor_stats.json"
+        with open(supervisor_path, 'w') as f:
+            json.dump(supervisor_stats, f)
+
+        daemon._publish_state([])
+
+        assert daemon.state.supervisor_launches == 5
+        assert daemon.state.supervisor_tokens == 10000
+        assert daemon.state.supervisor_claude_running is True
+        assert daemon.state.supervisor_claude_total_run_seconds == 300.0
+
+    def test_handles_missing_supervisor_stats(self, tmp_path, monkeypatch):
+        """Should handle gracefully when supervisor stats file does not exist."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+
+        # No supervisor stats file exists
+        daemon._publish_state([])
+
+        # Should still save state without error
+        state_path = tmp_path / "state.json"
+        assert state_path.exists()
+        assert daemon.state.supervisor_launches == 0
+
+    def test_updates_presence_state(self, tmp_path, monkeypatch):
+        """Should update presence state from PresenceComponent."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+
+        # Mock presence to return specific state
+        daemon.presence = Mock()
+        daemon.presence.available = True
+        daemon.presence.get_current_state.return_value = (3, 5.0, False)
+
+        daemon._publish_state([])
+
+        assert daemon.state.presence_available is True
+        assert daemon.state.presence_state == 3
+        assert daemon.state.presence_idle_seconds == 5.0
+
+    def test_calls_maybe_push_to_relay(self, tmp_path, monkeypatch):
+        """Should call _maybe_push_to_relay after saving state."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+
+        with patch.object(daemon, '_maybe_push_to_relay') as mock_relay:
+            daemon._publish_state([])
+
+        mock_relay.assert_called_once()
+
+
+class TestMaybePushToRelay:
+    """Test _maybe_push_to_relay method."""
+
+    def _make_daemon(self, tmp_path, monkeypatch):
+        """Helper to create a minimal MonitorDaemon for testing."""
+        from overcode.monitor_daemon import MonitorDaemon
+
+        monkeypatch.setattr('overcode.monitor_daemon.ensure_session_dir', lambda x: tmp_path)
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_monitor_daemon_pid_path',
+            lambda x: tmp_path / "pid"
+        )
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_monitor_daemon_state_path',
+            lambda x: tmp_path / "state.json"
+        )
+        monkeypatch.setattr(
+            'overcode.monitor_daemon.get_agent_history_path',
+            lambda x: tmp_path / "history.csv"
+        )
+
+        with patch('overcode.monitor_daemon.SessionManager') as mock_sm_cls:
+            with patch('overcode.monitor_daemon.StatusDetector'):
+                daemon = MonitorDaemon(tmux_session="test")
+                daemon.session_manager = mock_sm_cls.return_value
+        return daemon
+
+    def test_disabled_when_no_relay_config(self, tmp_path, monkeypatch):
+        """Should set status to disabled when relay_config is None."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+        daemon._relay_config = None
+
+        daemon._maybe_push_to_relay()
+
+        assert daemon.state.relay_enabled is False
+        assert daemon.state.relay_last_status == "disabled"
+
+    def test_skips_push_when_interval_not_elapsed(self, tmp_path, monkeypatch):
+        """Should not push when interval has not elapsed since last push."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+        daemon._relay_config = {"url": "https://example.com/update", "api_key": "key", "interval": 30}
+        daemon._last_relay_push = datetime.now()  # Just pushed
+
+        with patch('urllib.request.urlopen') as mock_urlopen:
+            daemon._maybe_push_to_relay()
+
+        # Should not have made a request (interval hasn't elapsed)
+        mock_urlopen.assert_not_called()
+        assert daemon.state.relay_enabled is True
+
+    def test_successful_push(self, tmp_path, monkeypatch):
+        """Should push state and update relay status on success."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+        daemon._relay_config = {"url": "https://example.com/update", "api_key": "secret", "interval": 30}
+        daemon._last_relay_push = datetime.min  # Force push
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.__enter__ = Mock(return_value=mock_response)
+        mock_response.__exit__ = Mock(return_value=False)
+
+        mock_status_data = {"agents": [], "status": "active"}
+
+        with patch('urllib.request.urlopen', return_value=mock_response) as mock_urlopen:
+            with patch('overcode.web_api.get_status_data', return_value=mock_status_data):
+                daemon._maybe_push_to_relay()
+
+        assert daemon.state.relay_enabled is True
+        assert daemon.state.relay_last_status == "ok"
+        assert daemon.state.relay_last_push is not None
+
+    def test_failed_push_sets_error_status(self, tmp_path, monkeypatch):
+        """Should set error status on push failure."""
+        import urllib.error
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+        daemon._relay_config = {"url": "https://example.com/update", "api_key": "secret", "interval": 30}
+        daemon._last_relay_push = datetime.min  # Force push
+
+        mock_status_data = {"agents": [], "status": "active"}
+
+        with patch('urllib.request.urlopen', side_effect=urllib.error.URLError("connection refused")):
+            with patch('overcode.web_api.get_status_data', return_value=mock_status_data):
+                daemon._maybe_push_to_relay()
+
+        assert daemon.state.relay_last_status == "error"
+
+    def test_handles_generic_exception(self, tmp_path, monkeypatch):
+        """Should handle generic exceptions during relay push."""
+        daemon = self._make_daemon(tmp_path, monkeypatch)
+        daemon._relay_config = {"url": "https://example.com/update", "api_key": "secret", "interval": 30}
+        daemon._last_relay_push = datetime.min  # Force push
+
+        mock_status_data = {"agents": [], "status": "active"}
+
+        with patch('urllib.request.urlopen', side_effect=RuntimeError("unexpected")):
+            with patch('overcode.web_api.get_status_data', return_value=mock_status_data):
+                daemon._maybe_push_to_relay()
+
+        assert daemon.state.relay_last_status == "error"
+
+
 # =============================================================================
 # Run tests directly
 # =============================================================================

--- a/tests/unit/test_session_summary.py
+++ b/tests/unit/test_session_summary.py
@@ -1,0 +1,385 @@
+"""Tests for session_summary widget module."""
+
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from overcode.session_manager import Session, SessionStats
+from overcode.history_reader import ClaudeSessionStats
+from overcode.tui_widgets.session_summary import (
+    format_standing_instructions,
+    SessionSummary,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build mock objects
+# ---------------------------------------------------------------------------
+
+def _make_stats(**overrides) -> MagicMock:
+    """Create a mock SessionStats with sensible defaults."""
+    defaults = dict(
+        current_state="running",
+        state_since=None,
+        green_time_seconds=100.0,
+        non_green_time_seconds=50.0,
+        sleep_time_seconds=0.0,
+        steers_count=0,
+        estimated_cost_usd=0.0,
+        current_task="",
+    )
+    defaults.update(overrides)
+    mock = MagicMock(spec=SessionStats)
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+def _make_session(**overrides) -> MagicMock:
+    """Create a mock Session with sensible defaults."""
+    defaults = dict(
+        id="test-id",
+        name="test-agent",
+        status="active",
+        stats=_make_stats(),
+        repo_name="test-repo",
+        branch="main",
+        standing_instructions=None,
+        standing_orders_complete=False,
+        standing_instructions_preset=None,
+        is_asleep=False,
+        time_context_enabled=False,
+        agent_value=1000,
+        permissiveness_mode="normal",
+        start_time="2025-01-15T10:00:00",
+        human_annotation=None,
+        heartbeat_enabled=False,
+        heartbeat_frequency_seconds=300,
+        heartbeat_paused=False,
+        last_heartbeat_time=None,
+        heartbeat_instruction=None,
+        tmux_window=1,
+        start_directory="/tmp/test",
+    )
+    defaults.update(overrides)
+    mock = MagicMock(spec=Session)
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+def _make_bare_widget(**extra_attrs) -> SessionSummary:
+    """Create a SessionSummary instance bypassing __init__.
+
+    Sets the minimum attributes needed for unit-testing individual methods.
+    Textual's reactive descriptor requires ``_id``, ``_is_mounted``, and
+    ``_running`` to be present on the instance before reactive attributes
+    (like ``summary_detail``) can be read or written.
+    """
+    widget = SessionSummary.__new__(SessionSummary)
+    # Textual internals required for reactive attribute access
+    widget._id = "test-widget"
+    widget._is_mounted = False
+    widget._running = False
+    # Defaults that most methods expect to be present
+    widget.session = _make_session()
+    widget.detected_status = "running"
+    widget.current_activity = ""
+    widget.pane_content = []
+    widget.claude_stats = None
+    widget.git_diff_stats = None
+    widget.background_bash_count = 0
+    widget.live_subagent_count = 0
+    widget.is_unvisited_stalled = False
+    widget._status_changed_at = None
+    widget._last_known_status = "running"
+    widget.summary_detail = "low"
+    widget.summary_groups = {
+        "time": True,
+        "tokens": True,
+        "git": True,
+        "supervision": True,
+        "priority": True,
+        "performance": True,
+    }
+    # Apply any caller-specified overrides
+    for k, v in extra_attrs.items():
+        setattr(widget, k, v)
+    return widget
+
+
+# ===========================================================================
+# format_standing_instructions
+# ===========================================================================
+
+
+class TestFormatStandingInstructions:
+    """Tests for the format_standing_instructions pure function."""
+
+    def test_empty_string_returns_empty(self):
+        """Empty string input returns empty string."""
+        with patch("overcode.config.get_default_standing_instructions", return_value=""):
+            assert format_standing_instructions("") == ""
+
+    def test_none_returns_empty(self):
+        """None input returns empty string."""
+        with patch("overcode.config.get_default_standing_instructions", return_value=""):
+            assert format_standing_instructions(None) == ""
+
+    def test_default_instructions_returns_label(self):
+        """Instructions matching the configured default show '[DEFAULT]'."""
+        default_text = "Always run tests before committing"
+        with patch(
+            "overcode.config.get_default_standing_instructions",
+            return_value=default_text,
+        ):
+            assert format_standing_instructions(default_text) == "[DEFAULT]"
+
+    def test_default_instructions_with_surrounding_whitespace(self):
+        """Whitespace-padded instructions still match the default."""
+        default_text = "Always run tests"
+        with patch(
+            "overcode.config.get_default_standing_instructions",
+            return_value=default_text,
+        ):
+            assert format_standing_instructions("  Always run tests  ") == "[DEFAULT]"
+
+    def test_short_instructions_returned_as_is(self):
+        """Instructions within max_len are returned unchanged."""
+        text = "Fix the login bug"
+        with patch(
+            "overcode.config.get_default_standing_instructions",
+            return_value="",
+        ):
+            assert format_standing_instructions(text) == text
+
+    def test_long_instructions_are_truncated(self):
+        """Instructions exceeding max_len are truncated with ellipsis."""
+        text = "A" * 100  # Longer than default max_len=95
+        with patch(
+            "overcode.config.get_default_standing_instructions",
+            return_value="",
+        ):
+            result = format_standing_instructions(text)
+            assert result.endswith("...")
+            assert len(result) == 95
+
+    def test_custom_max_len(self):
+        """Custom max_len is respected."""
+        text = "A" * 50
+        with patch(
+            "overcode.config.get_default_standing_instructions",
+            return_value="",
+        ):
+            result = format_standing_instructions(text, max_len=30)
+            assert result.endswith("...")
+            assert len(result) == 30
+
+    def test_exact_max_len_not_truncated(self):
+        """Instructions exactly at max_len are not truncated."""
+        text = "A" * 95
+        with patch(
+            "overcode.config.get_default_standing_instructions",
+            return_value="",
+        ):
+            result = format_standing_instructions(text)
+            assert result == text
+            assert "..." not in result
+
+    def test_no_default_configured_does_not_match(self):
+        """When no default is configured, non-empty instructions are returned as-is."""
+        with patch(
+            "overcode.config.get_default_standing_instructions",
+            return_value="",
+        ):
+            result = format_standing_instructions("some instructions")
+            assert result == "some instructions"
+
+
+# ===========================================================================
+# group_enabled
+# ===========================================================================
+
+
+class TestGroupEnabled:
+    """Tests for SessionSummary.group_enabled."""
+
+    def test_non_custom_mode_always_returns_true(self):
+        """In low/med/full modes all groups are enabled regardless of settings."""
+        for mode in ("low", "med", "full"):
+            widget = _make_bare_widget(summary_detail=mode)
+            widget.summary_groups = {"time": False, "tokens": False}
+            assert widget.group_enabled("time") is True
+            assert widget.group_enabled("tokens") is True
+
+    def test_custom_mode_respects_enabled_group(self):
+        """In custom mode, an enabled group returns True."""
+        widget = _make_bare_widget(
+            summary_detail="custom",
+            summary_groups={"time": True},
+        )
+        assert widget.group_enabled("time") is True
+
+    def test_custom_mode_respects_disabled_group(self):
+        """In custom mode, a disabled group returns False."""
+        widget = _make_bare_widget(
+            summary_detail="custom",
+            summary_groups={"tokens": False},
+        )
+        assert widget.group_enabled("tokens") is False
+
+    def test_custom_mode_unknown_group_defaults_true(self):
+        """Unknown group IDs default to True even in custom mode."""
+        widget = _make_bare_widget(
+            summary_detail="custom",
+            summary_groups={},
+        )
+        assert widget.group_enabled("nonexistent_group") is True
+
+    def test_custom_mode_multiple_groups_mixed(self):
+        """In custom mode, each group is checked independently."""
+        widget = _make_bare_widget(
+            summary_detail="custom",
+            summary_groups={
+                "time": True,
+                "tokens": False,
+                "git": True,
+                "supervision": False,
+                "priority": True,
+                "performance": False,
+            },
+        )
+        assert widget.group_enabled("time") is True
+        assert widget.group_enabled("tokens") is False
+        assert widget.group_enabled("git") is True
+        assert widget.group_enabled("supervision") is False
+        assert widget.group_enabled("priority") is True
+        assert widget.group_enabled("performance") is False
+
+
+# ===========================================================================
+# apply_status_no_refresh
+# ===========================================================================
+
+
+class TestApplyStatusNoRefresh:
+    """Tests for SessionSummary.apply_status_no_refresh."""
+
+    def test_updates_current_activity(self):
+        """Activity string is stored on the widget."""
+        widget = _make_bare_widget()
+        widget.apply_status_no_refresh("running", "Editing files", "", None, None)
+        assert widget.current_activity == "Editing files"
+
+    def test_parses_pane_content_into_lines(self):
+        """Content is split into lines and stored (last 50 max)."""
+        content = "\n".join(f"line {i}" for i in range(100))
+        widget = _make_bare_widget()
+        widget.apply_status_no_refresh("running", "", content, None, None)
+        assert len(widget.pane_content) == 50
+        assert widget.pane_content[-1] == "line 99"
+        assert widget.pane_content[0] == "line 50"
+
+    def test_empty_content_clears_pane_and_counts(self):
+        """Empty/falsy content resets pane_content and live counts to zero."""
+        widget = _make_bare_widget()
+        widget.pane_content = ["old line"]
+        widget.background_bash_count = 3
+        widget.live_subagent_count = 2
+        widget.apply_status_no_refresh("running", "", "", None, None)
+        assert widget.pane_content == []
+        assert widget.background_bash_count == 0
+        assert widget.live_subagent_count == 0
+
+    def test_asleep_session_overrides_status(self):
+        """If the session is_asleep, detected_status is set to 'asleep'."""
+        session = _make_session(is_asleep=True)
+        widget = _make_bare_widget(session=session)
+        widget.apply_status_no_refresh("running", "Active work", "", None, None)
+        assert widget.detected_status == "asleep"
+
+    def test_status_change_updates_timestamp(self):
+        """When the status changes, _status_changed_at is updated."""
+        widget = _make_bare_widget()
+        widget._last_known_status = "running"
+        before = datetime.now()
+        widget.apply_status_no_refresh("waiting_user", "Waiting", "", None, None)
+        after = datetime.now()
+        assert widget._status_changed_at is not None
+        assert before <= widget._status_changed_at <= after
+        assert widget._last_known_status == "waiting_user"
+
+    def test_same_status_does_not_update_timestamp(self):
+        """If the status has not changed, _status_changed_at remains unchanged."""
+        widget = _make_bare_widget()
+        widget._last_known_status = "running"
+        widget._status_changed_at = None
+        widget.apply_status_no_refresh("running", "Still working", "", None, None)
+        assert widget._status_changed_at is None
+
+    def test_claude_stats_stored_when_provided(self):
+        """Pre-fetched ClaudeSessionStats are saved on the widget."""
+        stats = MagicMock(spec=ClaudeSessionStats)
+        widget = _make_bare_widget()
+        widget.apply_status_no_refresh("running", "", "", stats, None)
+        assert widget.claude_stats is stats
+
+    def test_claude_stats_not_overwritten_when_none(self):
+        """Passing None for claude_stats does not clear a previously set value."""
+        old_stats = MagicMock(spec=ClaudeSessionStats)
+        widget = _make_bare_widget()
+        widget.claude_stats = old_stats
+        widget.apply_status_no_refresh("running", "", "", None, None)
+        assert widget.claude_stats is old_stats
+
+    def test_git_diff_stats_stored_when_provided(self):
+        """Pre-fetched git diff stats tuple is saved."""
+        diff = (5, 100, 20)
+        widget = _make_bare_widget()
+        widget.apply_status_no_refresh("running", "", "", None, diff)
+        assert widget.git_diff_stats == (5, 100, 20)
+
+    def test_git_diff_stats_not_overwritten_when_none(self):
+        """Passing None for git_diff_stats does not clear a previously set value."""
+        widget = _make_bare_widget()
+        widget.git_diff_stats = (3, 50, 10)
+        widget.apply_status_no_refresh("running", "", "", None, None)
+        assert widget.git_diff_stats == (3, 50, 10)
+
+    @patch("overcode.tui_widgets.session_summary.extract_background_bash_count", return_value=3)
+    @patch("overcode.tui_widgets.session_summary.extract_live_subagent_count", return_value=2)
+    def test_extracts_live_counts_from_content(self, mock_sub, mock_bash):
+        """Background bash and subagent counts are extracted from content."""
+        widget = _make_bare_widget()
+        widget.apply_status_no_refresh("running", "", "some pane content", None, None)
+        assert widget.background_bash_count == 3
+        assert widget.live_subagent_count == 2
+
+
+# ===========================================================================
+# Message classes
+# ===========================================================================
+
+
+class TestMessageClasses:
+    """Tests for the Textual message classes on SessionSummary."""
+
+    def test_session_selected_stores_id(self):
+        """SessionSelected message stores session_id."""
+        msg = SessionSummary.SessionSelected("abc-123")
+        assert msg.session_id == "abc-123"
+
+    def test_expanded_changed_stores_id_and_state(self):
+        """ExpandedChanged message stores session_id and expanded flag."""
+        msg = SessionSummary.ExpandedChanged("abc-123", True)
+        assert msg.session_id == "abc-123"
+        assert msg.expanded is True
+
+        msg2 = SessionSummary.ExpandedChanged("xyz", False)
+        assert msg2.session_id == "xyz"
+        assert msg2.expanded is False
+
+    def test_stalled_agent_visited_stores_id(self):
+        """StalledAgentVisited message stores session_id."""
+        msg = SessionSummary.StalledAgentVisited("stalled-1")
+        assert msg.session_id == "stalled-1"

--- a/tests/unit/test_tui_actions_session.py
+++ b/tests/unit/test_tui_actions_session.py
@@ -108,6 +108,785 @@ class TestToggleSleep:
         assert mock_tui.notify.call_args[1]["severity"] == "warning"
 
 
+class TestToggleFocused:
+    """Test action_toggle_focused method."""
+
+    def test_toggles_expansion_in_tree_mode(self):
+        """Should toggle expanded state when in tree mode."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.expanded = False
+
+        mock_tui = MagicMock()
+        mock_tui.view_mode = "tree"
+        mock_tui.focused = mock_widget
+
+        SessionActionsMixin.action_toggle_focused(mock_tui)
+
+        assert mock_widget.expanded is True
+
+    def test_collapses_expanded_widget(self):
+        """Should collapse an expanded widget."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.expanded = True
+
+        mock_tui = MagicMock()
+        mock_tui.view_mode = "tree"
+        mock_tui.focused = mock_widget
+
+        SessionActionsMixin.action_toggle_focused(mock_tui)
+
+        assert mock_widget.expanded is False
+
+    def test_noop_in_list_preview_mode(self):
+        """Should do nothing when in list_preview mode."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.expanded = False
+
+        mock_tui = MagicMock()
+        mock_tui.view_mode = "list_preview"
+        mock_tui.focused = mock_widget
+
+        SessionActionsMixin.action_toggle_focused(mock_tui)
+
+        # expanded should remain False (not toggled)
+        assert mock_widget.expanded is False
+
+    def test_noop_when_no_session_focused(self):
+        """Should do nothing when focused widget is not a SessionSummary."""
+        from overcode.tui_actions.session import SessionActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.view_mode = "tree"
+        mock_tui.focused = MagicMock()  # Not a SessionSummary
+
+        # Should not raise
+        SessionActionsMixin.action_toggle_focused(mock_tui)
+
+
+class TestToggleTimeContext:
+    """Test action_toggle_time_context method."""
+
+    def test_enables_time_context(self):
+        """Should enable time context on a session that has it disabled."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_session = MagicMock()
+        mock_session.time_context_enabled = False
+        mock_session.name = "test-agent"
+        mock_session.id = "session-123"
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+
+        mock_tui = MagicMock()
+        mock_tui.focused = mock_widget
+
+        SessionActionsMixin.action_toggle_time_context(mock_tui)
+
+        mock_tui.session_manager.update_session.assert_called_once_with(
+            "session-123", time_context_enabled=True
+        )
+        assert mock_session.time_context_enabled is True
+        assert "enabled" in mock_tui.notify.call_args[0][0]
+        mock_widget.refresh.assert_called_once()
+
+    def test_disables_time_context(self):
+        """Should disable time context on a session that has it enabled."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_session = MagicMock()
+        mock_session.time_context_enabled = True
+        mock_session.name = "test-agent"
+        mock_session.id = "session-123"
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+
+        mock_tui = MagicMock()
+        mock_tui.focused = mock_widget
+
+        SessionActionsMixin.action_toggle_time_context(mock_tui)
+
+        mock_tui.session_manager.update_session.assert_called_once_with(
+            "session-123", time_context_enabled=False
+        )
+        assert mock_session.time_context_enabled is False
+        assert "disabled" in mock_tui.notify.call_args[0][0]
+
+    def test_no_agent_focused(self):
+        """Should warn when no agent is focused."""
+        from overcode.tui_actions.session import SessionActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.focused = MagicMock()  # Not a SessionSummary
+
+        SessionActionsMixin.action_toggle_time_context(mock_tui)
+
+        mock_tui.notify.assert_called_once()
+        assert "No agent focused" in mock_tui.notify.call_args[0][0]
+
+
+class TestKillFocused:
+    """Test action_kill_focused method."""
+
+    def test_first_press_sets_pending(self):
+        """First press should set _pending_kill and show confirmation."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_session = MagicMock()
+        mock_session.name = "test-agent"
+        mock_session.id = "session-123"
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+
+        mock_tui = MagicMock()
+        mock_tui.focused = mock_widget
+        mock_tui._pending_kill = None
+
+        SessionActionsMixin.action_kill_focused(mock_tui)
+
+        # Should set _pending_kill with session name and timestamp
+        assert mock_tui._pending_kill is not None
+        assert mock_tui._pending_kill[0] == "test-agent"
+        mock_tui.notify.assert_called_once()
+        assert "Press x again" in mock_tui.notify.call_args[0][0]
+
+    def test_second_press_within_window_executes_kill(self):
+        """Second press within 3s should execute the kill."""
+        import time
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_session = MagicMock()
+        mock_session.name = "test-agent"
+        mock_session.id = "session-123"
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+
+        mock_tui = MagicMock()
+        mock_tui.focused = mock_widget
+        mock_tui._pending_kill = ("test-agent", time.time())  # Just set
+
+        SessionActionsMixin.action_kill_focused(mock_tui)
+
+        # Should execute the kill
+        mock_tui._execute_kill.assert_called_once_with(
+            mock_widget, "test-agent", "session-123"
+        )
+        assert mock_tui._pending_kill is None
+
+    def test_second_press_after_timeout_resets(self):
+        """Second press after 3s should start a new confirmation."""
+        import time
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_session = MagicMock()
+        mock_session.name = "test-agent"
+        mock_session.id = "session-123"
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+
+        mock_tui = MagicMock()
+        mock_tui.focused = mock_widget
+        mock_tui._pending_kill = ("test-agent", time.time() - 5.0)  # Expired
+
+        SessionActionsMixin.action_kill_focused(mock_tui)
+
+        # Should NOT execute kill; should start new confirmation
+        mock_tui._execute_kill.assert_not_called()
+        assert mock_tui._pending_kill is not None
+        assert mock_tui._pending_kill[0] == "test-agent"
+        mock_tui.notify.assert_called_once()
+        assert "Press x again" in mock_tui.notify.call_args[0][0]
+
+    def test_different_session_resets_pending(self):
+        """Pressing kill on different session should start new confirmation."""
+        import time
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_session = MagicMock()
+        mock_session.name = "other-agent"
+        mock_session.id = "session-456"
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+
+        mock_tui = MagicMock()
+        mock_tui.focused = mock_widget
+        mock_tui._pending_kill = ("test-agent", time.time())  # Different session
+
+        SessionActionsMixin.action_kill_focused(mock_tui)
+
+        # Should NOT execute kill; should set new pending for "other-agent"
+        mock_tui._execute_kill.assert_not_called()
+        assert mock_tui._pending_kill[0] == "other-agent"
+
+    def test_no_agent_focused(self):
+        """Should warn when no agent is focused."""
+        from overcode.tui_actions.session import SessionActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.focused = MagicMock()  # Not a SessionSummary
+
+        SessionActionsMixin.action_kill_focused(mock_tui)
+
+        mock_tui.notify.assert_called_once()
+        assert "No agent focused" in mock_tui.notify.call_args[0][0]
+
+
+class TestRestartFocused:
+    """Test action_restart_focused method."""
+
+    def test_first_press_sets_pending(self):
+        """First press should set _pending_restart and show confirmation."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_session = MagicMock()
+        mock_session.name = "test-agent"
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+
+        mock_tui = MagicMock()
+        mock_tui.focused = mock_widget
+        mock_tui._pending_restart = None
+
+        SessionActionsMixin.action_restart_focused(mock_tui)
+
+        assert mock_tui._pending_restart is not None
+        assert mock_tui._pending_restart[0] == "test-agent"
+        assert "Press R again" in mock_tui.notify.call_args[0][0]
+
+    def test_second_press_within_window_executes_restart(self):
+        """Second press within 3s should execute the restart."""
+        import time
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_session = MagicMock()
+        mock_session.name = "test-agent"
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+
+        mock_tui = MagicMock()
+        mock_tui.focused = mock_widget
+        mock_tui._pending_restart = ("test-agent", time.time())
+
+        SessionActionsMixin.action_restart_focused(mock_tui)
+
+        mock_tui._execute_restart.assert_called_once_with(mock_widget)
+        assert mock_tui._pending_restart is None
+
+    def test_second_press_after_timeout_resets(self):
+        """Second press after 3s should start a new confirmation."""
+        import time
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_session = MagicMock()
+        mock_session.name = "test-agent"
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+
+        mock_tui = MagicMock()
+        mock_tui.focused = mock_widget
+        mock_tui._pending_restart = ("test-agent", time.time() - 5.0)
+
+        SessionActionsMixin.action_restart_focused(mock_tui)
+
+        mock_tui._execute_restart.assert_not_called()
+        assert mock_tui._pending_restart[0] == "test-agent"
+
+    def test_no_agent_focused(self):
+        """Should warn when no agent is focused."""
+        from overcode.tui_actions.session import SessionActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.focused = MagicMock()
+
+        SessionActionsMixin.action_restart_focused(mock_tui)
+
+        mock_tui.notify.assert_called_once()
+        assert "No agent focused" in mock_tui.notify.call_args[0][0]
+
+
+class TestSyncToMainAndClear:
+    """Test action_sync_to_main_and_clear method."""
+
+    def test_first_press_sets_pending(self):
+        """First press should set _pending_sync and show confirmation."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_session = MagicMock()
+        mock_session.name = "test-agent"
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+
+        mock_tui = MagicMock()
+        mock_tui.focused = mock_widget
+        mock_tui._pending_sync = None
+
+        SessionActionsMixin.action_sync_to_main_and_clear(mock_tui)
+
+        assert mock_tui._pending_sync is not None
+        assert mock_tui._pending_sync[0] == "test-agent"
+        assert "Press c again" in mock_tui.notify.call_args[0][0]
+
+    def test_second_press_within_window_executes_sync(self):
+        """Second press within 3s should execute the sync."""
+        import time
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_session = MagicMock()
+        mock_session.name = "test-agent"
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+
+        mock_tui = MagicMock()
+        mock_tui.focused = mock_widget
+        mock_tui._pending_sync = ("test-agent", time.time())
+
+        SessionActionsMixin.action_sync_to_main_and_clear(mock_tui)
+
+        mock_tui._execute_sync.assert_called_once_with(mock_widget)
+        assert mock_tui._pending_sync is None
+
+    def test_second_press_after_timeout_resets(self):
+        """Second press after 3s should start a new confirmation."""
+        import time
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_session = MagicMock()
+        mock_session.name = "test-agent"
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+
+        mock_tui = MagicMock()
+        mock_tui.focused = mock_widget
+        mock_tui._pending_sync = ("test-agent", time.time() - 5.0)
+
+        SessionActionsMixin.action_sync_to_main_and_clear(mock_tui)
+
+        mock_tui._execute_sync.assert_not_called()
+        assert mock_tui._pending_sync[0] == "test-agent"
+
+    def test_no_agent_focused(self):
+        """Should warn when no agent is focused."""
+        from overcode.tui_actions.session import SessionActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.focused = MagicMock()
+
+        SessionActionsMixin.action_sync_to_main_and_clear(mock_tui)
+
+        mock_tui.notify.assert_called_once()
+        assert "No agent focused" in mock_tui.notify.call_args[0][0]
+
+
+class TestTransportAll:
+    """Test action_transport_all method."""
+
+    def test_first_press_sets_pending_with_active_sessions(self):
+        """First press with active sessions should set _pending_transport."""
+        from overcode.tui_actions.session import SessionActionsMixin
+
+        session1 = MagicMock()
+        session1.status = "running"
+        session1.is_asleep = False
+
+        session2 = MagicMock()
+        session2.status = "waiting"
+        session2.is_asleep = False
+
+        mock_tui = MagicMock()
+        mock_tui.sessions = [session1, session2]
+        mock_tui._pending_transport = None
+
+        SessionActionsMixin.action_transport_all(mock_tui)
+
+        assert mock_tui._pending_transport is not None
+        assert "Press H again" in mock_tui.notify.call_args[0][0]
+        assert "2 agent(s)" in mock_tui.notify.call_args[0][0]
+
+    def test_excludes_terminated_and_sleeping_sessions(self):
+        """Should exclude terminated and sleeping sessions from count."""
+        from overcode.tui_actions.session import SessionActionsMixin
+
+        active = MagicMock()
+        active.status = "running"
+        active.is_asleep = False
+
+        terminated = MagicMock()
+        terminated.status = "terminated"
+        terminated.is_asleep = False
+
+        sleeping = MagicMock()
+        sleeping.status = "running"
+        sleeping.is_asleep = True
+
+        mock_tui = MagicMock()
+        mock_tui.sessions = [active, terminated, sleeping]
+        mock_tui._pending_transport = None
+
+        SessionActionsMixin.action_transport_all(mock_tui)
+
+        assert "1 agent(s)" in mock_tui.notify.call_args[0][0]
+
+    def test_no_active_sessions_warns(self):
+        """Should warn if there are no active sessions."""
+        from overcode.tui_actions.session import SessionActionsMixin
+
+        terminated = MagicMock()
+        terminated.status = "terminated"
+        terminated.is_asleep = False
+
+        mock_tui = MagicMock()
+        mock_tui.sessions = [terminated]
+        mock_tui._pending_transport = None
+
+        SessionActionsMixin.action_transport_all(mock_tui)
+
+        mock_tui.notify.assert_called_once()
+        assert "No active sessions" in mock_tui.notify.call_args[0][0]
+        assert mock_tui._pending_transport is None
+
+    def test_second_press_within_window_executes(self):
+        """Second press within 3s should call _execute_transport_all."""
+        import time
+        from overcode.tui_actions.session import SessionActionsMixin
+
+        session1 = MagicMock()
+        session1.status = "running"
+        session1.is_asleep = False
+
+        mock_tui = MagicMock()
+        mock_tui.sessions = [session1]
+        mock_tui._pending_transport = time.time()
+
+        SessionActionsMixin.action_transport_all(mock_tui)
+
+        mock_tui._execute_transport_all.assert_called_once_with([session1])
+        assert mock_tui._pending_transport is None
+
+    def test_second_press_after_timeout_resets(self):
+        """Second press after 3s should start a new confirmation."""
+        import time
+        from overcode.tui_actions.session import SessionActionsMixin
+
+        session1 = MagicMock()
+        session1.status = "running"
+        session1.is_asleep = False
+
+        mock_tui = MagicMock()
+        mock_tui.sessions = [session1]
+        mock_tui._pending_transport = time.time() - 5.0
+
+        SessionActionsMixin.action_transport_all(mock_tui)
+
+        mock_tui._execute_transport_all.assert_not_called()
+        assert mock_tui._pending_transport is not None
+
+
+class TestNewAgent:
+    """Test action_new_agent method."""
+
+    def test_opens_command_bar_in_new_agent_dir_mode(self):
+        """Should open command bar with new_agent_dir mode."""
+        from overcode.tui_actions.session import SessionActionsMixin
+
+        mock_cmd_bar = MagicMock()
+        mock_input = MagicMock()
+        mock_cmd_bar.query_one.return_value = mock_input
+
+        mock_tui = MagicMock()
+        mock_tui.query_one.return_value = mock_cmd_bar
+
+        SessionActionsMixin.action_new_agent(mock_tui)
+
+        mock_cmd_bar.add_class.assert_called_once_with("visible")
+        mock_cmd_bar.set_mode.assert_called_once_with("new_agent_dir")
+        mock_cmd_bar.focus_input.assert_called_once()
+
+    def test_handles_no_matches(self):
+        """Should handle NoMatches gracefully when command bar is not found."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from textual.css.query import NoMatches
+
+        mock_tui = MagicMock()
+        mock_tui.query_one.side_effect = NoMatches()
+
+        SessionActionsMixin.action_new_agent(mock_tui)
+
+        mock_tui.notify.assert_called_once()
+        assert "Command bar not found" in mock_tui.notify.call_args[0][0]
+
+
+class TestFocusCommandBar:
+    """Test action_focus_command_bar method."""
+
+    def test_opens_and_focuses_command_bar(self):
+        """Should show and focus the command bar."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_session = MagicMock()
+        mock_session.name = "test-agent"
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+
+        mock_input = MagicMock()
+        mock_cmd_bar = MagicMock()
+        mock_cmd_bar.query_one.return_value = mock_input
+
+        mock_tui = MagicMock()
+        mock_tui.query_one.return_value = mock_cmd_bar
+        mock_tui.focused = mock_widget
+
+        SessionActionsMixin.action_focus_command_bar(mock_tui)
+
+        mock_cmd_bar.add_class.assert_called_once_with("visible")
+        mock_cmd_bar.set_target.assert_called_once_with("test-agent")
+        mock_input.focus.assert_called_once()
+
+    def test_defaults_to_first_session_when_no_focus(self):
+        """Should default to first session when no session is focused."""
+        from overcode.tui_actions.session import SessionActionsMixin
+
+        mock_session = MagicMock()
+        mock_session.name = "first-agent"
+
+        mock_input = MagicMock()
+        mock_cmd_bar = MagicMock()
+        mock_cmd_bar.target_session = None
+        mock_cmd_bar.query_one.return_value = mock_input
+
+        mock_tui = MagicMock()
+        mock_tui.query_one.return_value = mock_cmd_bar
+        mock_tui.focused = MagicMock()  # Not a SessionSummary
+        mock_tui.sessions = [mock_session]
+
+        SessionActionsMixin.action_focus_command_bar(mock_tui)
+
+        mock_cmd_bar.set_target.assert_called_once_with("first-agent")
+
+    def test_handles_no_matches(self):
+        """Should handle NoMatches gracefully."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from textual.css.query import NoMatches
+
+        mock_tui = MagicMock()
+        mock_tui.query_one.side_effect = NoMatches()
+
+        # Should not raise
+        SessionActionsMixin.action_focus_command_bar(mock_tui)
+
+
+class TestFocusStandingOrders:
+    """Test action_focus_standing_orders method."""
+
+    def test_opens_command_bar_in_standing_orders_mode(self):
+        """Should open command bar with standing_orders mode and pre-fill."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_session = MagicMock()
+        mock_session.name = "test-agent"
+        mock_session.standing_instructions = "Do the thing"
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+
+        mock_input = MagicMock()
+        mock_cmd_bar = MagicMock()
+        mock_cmd_bar.query_one.return_value = mock_input
+
+        mock_tui = MagicMock()
+        mock_tui.query_one.return_value = mock_cmd_bar
+        mock_tui.focused = mock_widget
+
+        SessionActionsMixin.action_focus_standing_orders(mock_tui)
+
+        mock_cmd_bar.set_target.assert_called_once_with("test-agent")
+        mock_cmd_bar.set_mode.assert_called_once_with("standing_orders")
+        # Should pre-fill with existing standing orders
+        assert mock_input.value == "Do the thing"
+
+
+class TestFocusHumanAnnotation:
+    """Test action_focus_human_annotation method."""
+
+    def test_opens_command_bar_in_annotation_mode(self):
+        """Should open command bar with annotation mode and pre-fill."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_session = MagicMock()
+        mock_session.name = "test-agent"
+        mock_session.human_annotation = "Needs review"
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+
+        mock_input = MagicMock()
+        mock_cmd_bar = MagicMock()
+        mock_cmd_bar.query_one.return_value = mock_input
+
+        mock_tui = MagicMock()
+        mock_tui.query_one.return_value = mock_cmd_bar
+        mock_tui.focused = mock_widget
+
+        SessionActionsMixin.action_focus_human_annotation(mock_tui)
+
+        mock_cmd_bar.set_target.assert_called_once_with("test-agent")
+        mock_cmd_bar.set_mode.assert_called_once_with("annotation")
+        assert mock_input.value == "Needs review"
+
+
+class TestEditAgentValue:
+    """Test action_edit_agent_value method."""
+
+    def test_opens_command_bar_in_value_mode(self):
+        """Should open command bar with value mode and pre-fill."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_session = MagicMock()
+        mock_session.name = "test-agent"
+        mock_session.agent_value = 500
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+
+        mock_input = MagicMock()
+        mock_cmd_bar = MagicMock()
+        mock_cmd_bar.query_one.return_value = mock_input
+
+        mock_tui = MagicMock()
+        mock_tui.query_one.return_value = mock_cmd_bar
+        mock_tui.focused = mock_widget
+
+        SessionActionsMixin.action_edit_agent_value(mock_tui)
+
+        mock_cmd_bar.set_target.assert_called_once_with("test-agent")
+        mock_cmd_bar.set_mode.assert_called_once_with("value")
+        assert mock_input.value == "500"
+
+    def test_defaults_to_1000_when_no_session_focused(self):
+        """Should default to 1000 when no session is focused."""
+        from overcode.tui_actions.session import SessionActionsMixin
+
+        mock_session = MagicMock()
+        mock_session.name = "first-agent"
+
+        mock_input = MagicMock()
+        mock_cmd_bar = MagicMock()
+        mock_cmd_bar.target_session = None
+        mock_cmd_bar.query_one.return_value = mock_input
+
+        mock_tui = MagicMock()
+        mock_tui.query_one.return_value = mock_cmd_bar
+        mock_tui.focused = MagicMock()  # Not a SessionSummary
+        mock_tui.sessions = [mock_session]
+
+        SessionActionsMixin.action_edit_agent_value(mock_tui)
+
+        mock_cmd_bar.set_target.assert_called_once_with("first-agent")
+        assert mock_input.value == "1000"
+
+
+class TestConfigureHeartbeat:
+    """Test action_configure_heartbeat method."""
+
+    def test_opens_command_bar_in_heartbeat_freq_mode_enabled(self):
+        """Should pre-fill with existing frequency when heartbeat is enabled."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_session = MagicMock()
+        mock_session.name = "test-agent"
+        mock_session.heartbeat_enabled = True
+        mock_session.heartbeat_frequency_seconds = 600
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+
+        mock_input = MagicMock()
+        mock_cmd_bar = MagicMock()
+        mock_cmd_bar.query_one.return_value = mock_input
+
+        mock_tui = MagicMock()
+        mock_tui.query_one.return_value = mock_cmd_bar
+        mock_tui.focused = mock_widget
+
+        SessionActionsMixin.action_configure_heartbeat(mock_tui)
+
+        mock_cmd_bar.set_target.assert_called_once_with("test-agent")
+        mock_cmd_bar.set_mode.assert_called_once_with("heartbeat_freq")
+        assert mock_input.value == "600"
+
+    def test_opens_command_bar_in_heartbeat_freq_mode_disabled(self):
+        """Should pre-fill with 300 (default) when heartbeat is disabled."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from overcode.tui_widgets import SessionSummary
+
+        mock_session = MagicMock()
+        mock_session.name = "test-agent"
+        mock_session.heartbeat_enabled = False
+
+        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget.session = mock_session
+
+        mock_input = MagicMock()
+        mock_cmd_bar = MagicMock()
+        mock_cmd_bar.query_one.return_value = mock_input
+
+        mock_tui = MagicMock()
+        mock_tui.query_one.return_value = mock_cmd_bar
+        mock_tui.focused = mock_widget
+
+        SessionActionsMixin.action_configure_heartbeat(mock_tui)
+
+        assert mock_input.value == "300"
+
+    def test_handles_no_matches(self):
+        """Should handle NoMatches gracefully."""
+        from overcode.tui_actions.session import SessionActionsMixin
+        from textual.css.query import NoMatches
+
+        mock_tui = MagicMock()
+        mock_tui.query_one.side_effect = NoMatches()
+
+        # Should not raise
+        SessionActionsMixin.action_configure_heartbeat(mock_tui)
+
+
 # =============================================================================
 # Run tests directly
 # =============================================================================

--- a/tests/unit/test_tui_actions_view.py
+++ b/tests/unit/test_tui_actions_view.py
@@ -1,0 +1,693 @@
+"""
+Unit tests for TUI view actions.
+
+Tests display settings, toggles, and visual modes that can be
+isolated from the full TUI.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+
+class TestToggleTimeline:
+    """Test action_toggle_timeline method."""
+
+    def test_hides_visible_timeline(self):
+        """Should hide the timeline when it is currently displayed."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_timeline = MagicMock()
+        mock_timeline.display = True
+
+        mock_tui = MagicMock()
+        mock_tui.query_one.return_value = mock_timeline
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_toggle_timeline(mock_tui)
+
+        assert mock_timeline.display is False
+        assert mock_tui._prefs.timeline_visible is False
+        mock_tui._save_prefs.assert_called_once()
+        assert "hidden" in mock_tui.notify.call_args[0][0]
+
+    def test_shows_hidden_timeline(self):
+        """Should show the timeline when it is currently hidden."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_timeline = MagicMock()
+        mock_timeline.display = False
+
+        mock_tui = MagicMock()
+        mock_tui.query_one.return_value = mock_timeline
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_toggle_timeline(mock_tui)
+
+        assert mock_timeline.display is True
+        assert mock_tui._prefs.timeline_visible is True
+        mock_tui._save_prefs.assert_called_once()
+        assert "shown" in mock_tui.notify.call_args[0][0]
+
+    def test_handles_no_matches(self):
+        """Should handle NoMatches gracefully when timeline is not found."""
+        from overcode.tui_actions.view import ViewActionsMixin
+        from textual.css.query import NoMatches
+
+        mock_tui = MagicMock()
+        mock_tui.query_one.side_effect = NoMatches()
+
+        # Should not raise
+        ViewActionsMixin.action_toggle_timeline(mock_tui)
+        mock_tui.notify.assert_not_called()
+
+
+class TestToggleHelp:
+    """Test action_toggle_help method."""
+
+    def test_shows_help_when_hidden(self):
+        """Should add visible class when help overlay is hidden."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_overlay = MagicMock()
+        mock_overlay.has_class.return_value = False
+
+        mock_tui = MagicMock()
+        mock_tui.query_one.return_value = mock_overlay
+
+        ViewActionsMixin.action_toggle_help(mock_tui)
+
+        mock_overlay.add_class.assert_called_once_with("visible")
+        mock_overlay.remove_class.assert_not_called()
+
+    def test_hides_help_when_visible(self):
+        """Should remove visible class when help overlay is shown."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_overlay = MagicMock()
+        mock_overlay.has_class.return_value = True
+
+        mock_tui = MagicMock()
+        mock_tui.query_one.return_value = mock_overlay
+
+        ViewActionsMixin.action_toggle_help(mock_tui)
+
+        mock_overlay.remove_class.assert_called_once_with("visible")
+        mock_overlay.add_class.assert_not_called()
+
+    def test_handles_no_matches(self):
+        """Should handle NoMatches gracefully when overlay is not found."""
+        from overcode.tui_actions.view import ViewActionsMixin
+        from textual.css.query import NoMatches
+
+        mock_tui = MagicMock()
+        mock_tui.query_one.side_effect = NoMatches()
+
+        # Should not raise
+        ViewActionsMixin.action_toggle_help(mock_tui)
+
+
+class TestManualRefresh:
+    """Test action_manual_refresh method."""
+
+    def test_calls_all_refresh_methods(self):
+        """Should call all four refresh methods and notify."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+
+        ViewActionsMixin.action_manual_refresh(mock_tui)
+
+        mock_tui.refresh_sessions.assert_called_once()
+        mock_tui.update_all_statuses.assert_called_once()
+        mock_tui.update_daemon_status.assert_called_once()
+        mock_tui.update_timeline.assert_called_once()
+        mock_tui.notify.assert_called_once()
+        assert "Refreshed" in mock_tui.notify.call_args[0][0]
+
+
+class TestToggleExpandAll:
+    """Test action_toggle_expand_all method."""
+
+    def test_collapses_all_when_any_expanded(self):
+        """Should collapse all widgets when at least one is expanded."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        widget1 = MagicMock()
+        widget1.expanded = True
+        widget1.session.id = "s1"
+
+        widget2 = MagicMock()
+        widget2.expanded = False
+        widget2.session.id = "s2"
+
+        mock_tui = MagicMock()
+        mock_tui.query.return_value = [widget1, widget2]
+        mock_tui.expanded_states = {}
+
+        ViewActionsMixin.action_toggle_expand_all(mock_tui)
+
+        # When any are expanded, new_state = not True = False
+        assert widget1.expanded is False
+        assert widget2.expanded is False
+        assert mock_tui.expanded_states["s1"] is False
+        assert mock_tui.expanded_states["s2"] is False
+
+    def test_expands_all_when_none_expanded(self):
+        """Should expand all widgets when none are expanded."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        widget1 = MagicMock()
+        widget1.expanded = False
+        widget1.session.id = "s1"
+
+        widget2 = MagicMock()
+        widget2.expanded = False
+        widget2.session.id = "s2"
+
+        mock_tui = MagicMock()
+        mock_tui.query.return_value = [widget1, widget2]
+        mock_tui.expanded_states = {}
+
+        ViewActionsMixin.action_toggle_expand_all(mock_tui)
+
+        assert widget1.expanded is True
+        assert widget2.expanded is True
+
+    def test_noop_with_no_widgets(self):
+        """Should do nothing when there are no session widgets."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.query.return_value = []
+
+        # Should not raise
+        ViewActionsMixin.action_toggle_expand_all(mock_tui)
+
+
+class TestCycleDetail:
+    """Test action_cycle_detail method."""
+
+    def test_cycles_to_next_detail_level(self):
+        """Should cycle detail_level_index and update widgets."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        widget1 = MagicMock()
+        widget2 = MagicMock()
+
+        mock_tui = MagicMock()
+        mock_tui.detail_level_index = 0
+        mock_tui.DETAIL_LEVELS = [5, 10, 20, 50]
+        mock_tui.query.return_value = [widget1, widget2]
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_cycle_detail(mock_tui)
+
+        assert mock_tui.detail_level_index == 1
+        assert widget1.detail_lines == 10
+        assert widget2.detail_lines == 10
+        assert mock_tui._prefs.detail_lines == 10
+        mock_tui._save_prefs.assert_called_once()
+        assert "10 lines" in mock_tui.notify.call_args[0][0]
+
+    def test_wraps_around_at_end(self):
+        """Should wrap back to index 0 when at the last level."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.detail_level_index = 3  # Last index
+        mock_tui.DETAIL_LEVELS = [5, 10, 20, 50]
+        mock_tui.query.return_value = []
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_cycle_detail(mock_tui)
+
+        assert mock_tui.detail_level_index == 0
+        assert mock_tui._prefs.detail_lines == 5
+
+
+class TestCycleSummary:
+    """Test action_cycle_summary method."""
+
+    def test_cycles_to_next_summary_level(self):
+        """Should cycle summary_level_index and update widgets."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        widget1 = MagicMock()
+
+        mock_tui = MagicMock()
+        mock_tui.summary_level_index = 0
+        mock_tui.SUMMARY_LEVELS = ["low", "med", "full", "custom"]
+        mock_tui.query.return_value = [widget1]
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_cycle_summary(mock_tui)
+
+        assert mock_tui.summary_level_index == 1
+        assert widget1.summary_detail == "med"
+        assert mock_tui._prefs.summary_detail == "med"
+        mock_tui._save_prefs.assert_called_once()
+        assert "med" in mock_tui.notify.call_args[0][0]
+
+    def test_wraps_around_at_end(self):
+        """Should wrap back to index 0 when at the last level."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.summary_level_index = 3  # Last (custom)
+        mock_tui.SUMMARY_LEVELS = ["low", "med", "full", "custom"]
+        mock_tui.query.return_value = []
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_cycle_summary(mock_tui)
+
+        assert mock_tui.summary_level_index == 0
+        assert mock_tui._prefs.summary_detail == "low"
+
+
+class TestCycleSummaryContent:
+    """Test action_cycle_summary_content method."""
+
+    def test_cycles_to_next_content_mode(self):
+        """Should cycle summary_content_mode and update widgets."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        widget1 = MagicMock()
+
+        mock_tui = MagicMock()
+        mock_tui.summary_content_mode = "ai_short"
+        mock_tui.SUMMARY_CONTENT_MODES = [
+            "ai_short", "ai_long", "orders", "annotation", "heartbeat"
+        ]
+        mock_tui.query.return_value = [widget1]
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_cycle_summary_content(mock_tui)
+
+        assert mock_tui.summary_content_mode == "ai_long"
+        assert widget1.summary_content_mode == "ai_long"
+        assert mock_tui._prefs.summary_content_mode == "ai_long"
+        mock_tui._save_prefs.assert_called_once()
+        assert "AI Summary (context)" in mock_tui.notify.call_args[0][0]
+
+    def test_wraps_around_at_end(self):
+        """Should wrap back to first mode when at the end."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.summary_content_mode = "heartbeat"
+        mock_tui.SUMMARY_CONTENT_MODES = [
+            "ai_short", "ai_long", "orders", "annotation", "heartbeat"
+        ]
+        mock_tui.query.return_value = []
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_cycle_summary_content(mock_tui)
+
+        assert mock_tui.summary_content_mode == "ai_short"
+
+    def test_handles_unknown_current_mode(self):
+        """Should start from index 0 if current mode is not in the list."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.summary_content_mode = "nonexistent"
+        mock_tui.SUMMARY_CONTENT_MODES = [
+            "ai_short", "ai_long", "orders", "annotation", "heartbeat"
+        ]
+        mock_tui.query.return_value = []
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_cycle_summary_content(mock_tui)
+
+        # index 0 -> next is index 1
+        assert mock_tui.summary_content_mode == "ai_long"
+
+
+class TestToggleViewMode:
+    """Test action_toggle_view_mode method."""
+
+    def test_switches_from_tree_to_list_preview(self):
+        """Should switch from tree to list_preview mode."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.view_mode = "tree"
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_toggle_view_mode(mock_tui)
+
+        assert mock_tui.view_mode == "list_preview"
+        assert mock_tui._prefs.view_mode == "list_preview"
+        mock_tui._save_prefs.assert_called_once()
+
+    def test_switches_from_list_preview_to_tree(self):
+        """Should switch from list_preview to tree mode."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.view_mode = "list_preview"
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_toggle_view_mode(mock_tui)
+
+        assert mock_tui.view_mode == "tree"
+        assert mock_tui._prefs.view_mode == "tree"
+        mock_tui._save_prefs.assert_called_once()
+
+
+class TestToggleTmuxSync:
+    """Test action_toggle_tmux_sync method."""
+
+    def test_enables_tmux_sync(self):
+        """Should enable tmux sync and trigger immediate sync."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.tmux_sync = False
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_toggle_tmux_sync(mock_tui)
+
+        assert mock_tui.tmux_sync is True
+        assert mock_tui._prefs.tmux_sync is True
+        mock_tui._save_prefs.assert_called_once()
+        mock_tui._update_subtitle.assert_called_once()
+        mock_tui._sync_tmux_window.assert_called_once()
+
+    def test_disables_tmux_sync(self):
+        """Should disable tmux sync and not trigger immediate sync."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.tmux_sync = True
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_toggle_tmux_sync(mock_tui)
+
+        assert mock_tui.tmux_sync is False
+        assert mock_tui._prefs.tmux_sync is False
+        mock_tui._save_prefs.assert_called_once()
+        mock_tui._update_subtitle.assert_called_once()
+        # Should NOT call _sync_tmux_window when disabling
+        mock_tui._sync_tmux_window.assert_not_called()
+
+
+class TestToggleShowTerminated:
+    """Test action_toggle_show_terminated method."""
+
+    def test_enables_show_terminated(self):
+        """Should toggle show_terminated on and refresh widgets."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.show_terminated = False
+        mock_tui._terminated_sessions = ["s1", "s2"]
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_toggle_show_terminated(mock_tui)
+
+        assert mock_tui.show_terminated is True
+        assert mock_tui._prefs.show_terminated is True
+        mock_tui._save_prefs.assert_called_once()
+        mock_tui.update_session_widgets.assert_called_once()
+        assert "visible" in mock_tui.notify.call_args[0][0]
+        assert "2" in mock_tui.notify.call_args[0][0]
+
+    def test_disables_show_terminated(self):
+        """Should toggle show_terminated off and refresh widgets."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.show_terminated = True
+        mock_tui._terminated_sessions = []
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_toggle_show_terminated(mock_tui)
+
+        assert mock_tui.show_terminated is False
+        assert mock_tui._prefs.show_terminated is False
+        assert "hidden" in mock_tui.notify.call_args[0][0]
+
+
+class TestToggleHideAsleep:
+    """Test action_toggle_hide_asleep method."""
+
+    def test_enables_hide_asleep(self):
+        """Should toggle hide_asleep on and show count."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        session1 = MagicMock()
+        session1.is_asleep = True
+        session2 = MagicMock()
+        session2.is_asleep = False
+
+        mock_tui = MagicMock()
+        mock_tui.hide_asleep = False
+        mock_tui.sessions = [session1, session2]
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_toggle_hide_asleep(mock_tui)
+
+        assert mock_tui.hide_asleep is True
+        assert mock_tui._prefs.hide_asleep is True
+        mock_tui._save_prefs.assert_called_once()
+        mock_tui._update_subtitle.assert_called_once()
+        mock_tui.update_session_widgets.assert_called_once()
+        assert "hidden" in mock_tui.notify.call_args[0][0]
+        assert "1" in mock_tui.notify.call_args[0][0]
+
+    def test_disables_hide_asleep(self):
+        """Should toggle hide_asleep off and show visible count."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.hide_asleep = True
+        mock_tui.sessions = []
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_toggle_hide_asleep(mock_tui)
+
+        assert mock_tui.hide_asleep is False
+        assert "visible" in mock_tui.notify.call_args[0][0]
+
+
+class TestCycleSortMode:
+    """Test action_cycle_sort_mode method."""
+
+    @patch("overcode.tui_logic.get_sort_mode_display_name", return_value="By Status")
+    @patch("overcode.tui_logic.cycle_sort_mode", return_value="by_status")
+    def test_cycles_sort_mode(self, mock_cycle, mock_display_name):
+        """Should cycle sort mode and refresh."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        widget1 = MagicMock()
+        widget1.session.id = "s1"
+
+        mock_tui = MagicMock()
+        mock_tui._prefs = MagicMock()
+        mock_tui._prefs.sort_mode = "alphabetical"
+        mock_tui.SORT_MODES = ["alphabetical", "by_status", "by_value"]
+        mock_tui.focused_session_index = 0
+        mock_tui._get_widgets_in_session_order.return_value = [widget1]
+
+        ViewActionsMixin.action_cycle_sort_mode(mock_tui)
+
+        mock_cycle.assert_called_once_with("alphabetical", ["alphabetical", "by_status", "by_value"])
+        assert mock_tui._prefs.sort_mode == "by_status"
+        mock_tui._save_prefs.assert_called_once()
+        mock_tui._sort_sessions.assert_called_once()
+        mock_tui.update_session_widgets.assert_called_once()
+        mock_tui._update_subtitle.assert_called_once()
+        assert "By Status" in mock_tui.notify.call_args[0][0]
+
+    @patch("overcode.tui_logic.get_sort_mode_display_name", return_value="By Status")
+    @patch("overcode.tui_logic.cycle_sort_mode", return_value="by_status")
+    def test_follows_focused_session_after_sort(self, mock_cycle, mock_display_name):
+        """Should update focused_session_index to track the same session."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        widget_a = MagicMock()
+        widget_a.session.id = "s-alpha"
+        widget_b = MagicMock()
+        widget_b.session.id = "s-beta"
+
+        mock_tui = MagicMock()
+        mock_tui._prefs = MagicMock()
+        mock_tui._prefs.sort_mode = "alphabetical"
+        mock_tui.SORT_MODES = ["alphabetical", "by_status", "by_value"]
+        mock_tui.focused_session_index = 0
+
+        # Before sort: [alpha, beta]; after sort: [beta, alpha]
+        mock_tui._get_widgets_in_session_order.side_effect = [
+            [widget_a, widget_b],  # First call (before sort)
+            [widget_b, widget_a],  # Second call (after sort)
+        ]
+
+        ViewActionsMixin.action_cycle_sort_mode(mock_tui)
+
+        # Originally focused on s-alpha at index 0, now at index 1
+        assert mock_tui.focused_session_index == 1
+
+
+class TestBaselineBack:
+    """Test action_baseline_back method."""
+
+    def test_increments_by_15(self):
+        """Should increment baseline_minutes by 15."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.baseline_minutes = 30
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_baseline_back(mock_tui)
+
+        assert mock_tui.baseline_minutes == 45
+        assert mock_tui._prefs.baseline_minutes == 45
+        mock_tui._save_prefs.assert_called_once()
+        mock_tui._notify_baseline_change.assert_called_once()
+
+    def test_caps_at_180(self):
+        """Should not exceed 180 minutes (3 hours)."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.baseline_minutes = 170
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_baseline_back(mock_tui)
+
+        assert mock_tui.baseline_minutes == 180
+
+    def test_already_at_max(self):
+        """Should stay at 180 when already at max."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.baseline_minutes = 180
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_baseline_back(mock_tui)
+
+        assert mock_tui.baseline_minutes == 180
+
+
+class TestBaselineForward:
+    """Test action_baseline_forward method."""
+
+    def test_decrements_by_15(self):
+        """Should decrement baseline_minutes by 15."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.baseline_minutes = 45
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_baseline_forward(mock_tui)
+
+        assert mock_tui.baseline_minutes == 30
+        assert mock_tui._prefs.baseline_minutes == 30
+        mock_tui._save_prefs.assert_called_once()
+        mock_tui._notify_baseline_change.assert_called_once()
+
+    def test_caps_at_zero(self):
+        """Should not go below 0."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.baseline_minutes = 10
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_baseline_forward(mock_tui)
+
+        assert mock_tui.baseline_minutes == 0
+
+
+class TestBaselineReset:
+    """Test action_baseline_reset method."""
+
+    def test_resets_to_zero(self):
+        """Should reset baseline_minutes to 0."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.baseline_minutes = 90
+        mock_tui._prefs = MagicMock()
+
+        ViewActionsMixin.action_baseline_reset(mock_tui)
+
+        assert mock_tui.baseline_minutes == 0
+        assert mock_tui._prefs.baseline_minutes == 0
+        mock_tui._save_prefs.assert_called_once()
+        mock_tui._notify_baseline_change.assert_called_once()
+
+
+class TestNotifyBaselineChange:
+    """Test _notify_baseline_change method."""
+
+    def test_label_now(self):
+        """Should show 'now' when baseline is 0."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.baseline_minutes = 0
+
+        ViewActionsMixin._notify_baseline_change(mock_tui)
+
+        assert "now" in mock_tui.notify.call_args[0][0]
+        mock_tui.update_daemon_status.assert_called_once()
+        mock_tui.update_timeline.assert_called_once()
+
+    def test_label_minutes(self):
+        """Should show '-30m' for 30 minutes."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.baseline_minutes = 30
+
+        ViewActionsMixin._notify_baseline_change(mock_tui)
+
+        assert "-30m" in mock_tui.notify.call_args[0][0]
+
+    def test_label_exact_hours(self):
+        """Should show '-2h' for 120 minutes."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.baseline_minutes = 120
+
+        ViewActionsMixin._notify_baseline_change(mock_tui)
+
+        assert "-2h" in mock_tui.notify.call_args[0][0]
+        # Ensure it does NOT show minutes portion
+        assert "m" not in mock_tui.notify.call_args[0][0].replace("Baseline:", "").replace("-2h", "")
+
+    def test_label_hours_and_minutes(self):
+        """Should show '-1h30m' for 90 minutes."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.baseline_minutes = 90
+
+        ViewActionsMixin._notify_baseline_change(mock_tui)
+
+        assert "-1h30m" in mock_tui.notify.call_args[0][0]
+
+    def test_label_three_hours(self):
+        """Should show '-3h' for 180 minutes."""
+        from overcode.tui_actions.view import ViewActionsMixin
+
+        mock_tui = MagicMock()
+        mock_tui.baseline_minutes = 180
+
+        ViewActionsMixin._notify_baseline_change(mock_tui)
+
+        assert "-3h" in mock_tui.notify.call_args[0][0]
+
+
+# =============================================================================
+# Run tests directly
+# =============================================================================
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Added **225 new unit tests** across 7 test files targeting the least-covered modules
- Overall coverage improved from **54% to 61%** (+7 percentage points)
- All 1591 tests pass, 0 failures

## Per-module improvements

| Module | Before | After | New Tests |
|--------|--------|-------|-----------|
| `supervisor_daemon.py` | 21% | 56% | 44 |
| `tui_actions/session.py` | 20% | 82% | 37 |
| `tui_actions/view.py` | 22% | 65% | 38 |
| `web_api.py` | 58% | 83% | 26 |
| `web_server.py` | 38% | 52% | 21 |
| `monitor_daemon.py` | 23% | improved | 30 |
| `session_summary.py` | 10% | 18% | 28 |

## Test plan
- [x] All 1591 unit tests pass (`uv run pytest tests/unit/ -v`)
- [x] No regressions in existing tests
- [x] Coverage verified with `pytest-cov`

🤖 Generated with [Claude Code](https://claude.com/claude-code)