### PR TITLE
Fix 3 metric calculation bugs in summary line

### DIFF
--- a/src/overcode/monitor_daemon_core.py
+++ b/src/overcode/monitor_daemon_core.py
@@ -109,10 +109,10 @@ def calculate_cost_estimate(
     output_tokens: int,
     cache_creation_tokens: int = 0,
     cache_read_tokens: int = 0,
-    price_input: float = 15.0,
-    price_output: float = 75.0,
-    price_cache_write: float = 18.75,
-    price_cache_read: float = 1.50,
+    price_input: float = 5.0,
+    price_output: float = 25.0,
+    price_cache_write: float = 6.25,
+    price_cache_read: float = 0.50,
 ) -> float:
     """Calculate estimated cost from token counts.
 

--- a/src/overcode/tui_helpers.py
+++ b/src/overcode/tui_helpers.py
@@ -129,13 +129,16 @@ def format_line_count(count: int) -> str:
         count: Number of lines
 
     Returns:
-        Formatted string like "173K", "1.2M", or "500" for small counts.
-        Uses no decimal for K values to keep display compact.
+        Formatted string like "1.5K", "173K", "1.2M", or "500" for small counts.
+        Uses one decimal for values under 10K, integer for 10K+ to stay within
+        4 chars for layout alignment.
     """
     if count >= 1_000_000:
         return f"{count / 1_000_000:.1f}M"
-    elif count >= 1_000:
+    elif count >= 10_000:
         return f"{count // 1_000}K"
+    elif count >= 1_000:
+        return f"{count / 1_000:.1f}K"
     else:
         return str(count)
 
@@ -186,8 +189,9 @@ def calculate_percentiles(times: List[float]) -> Tuple[float, float, float]:
         return mean_time, mean_time, mean_time
 
     sorted_times = sorted(times)
-    p5_idx = int(len(sorted_times) * 0.05)
-    p95_idx = int(len(sorted_times) * 0.95)
+    n = len(sorted_times)
+    p5_idx = int(0.05 * (n - 1))
+    p95_idx = int(0.95 * (n - 1))
     p5 = sorted_times[p5_idx]
     p95 = sorted_times[p95_idx]
 

--- a/src/overcode/tui_widgets/session_summary.py
+++ b/src/overcode/tui_widgets/session_summary.py
@@ -382,15 +382,15 @@ class SessionSummary(Static, can_focus=True):
                 if self.summary_detail in ("full", "custom"):
                     # Full/Custom: show files and lines with fixed widths
                     content.append(f" Δ{files:>2}", style=mono(f"bold magenta{bg}", "bold"))
-                    content.append(f" +{format_line_count(ins):>4}", style=mono(f"bold green{bg}", "bold"))
-                    content.append(f" -{format_line_count(dels):>4}", style=mono(f"bold red{bg}", "dim"))
+                    content.append(f" +{format_line_count(ins):>5}", style=mono(f"bold green{bg}", "bold"))
+                    content.append(f" -{format_line_count(dels):>5}", style=mono(f"bold red{bg}", "dim"))
                 else:
                     # Compact: just files changed (fixed 4 char width)
                     content.append(f" Δ{files:>2}", style=mono(f"bold magenta{bg}" if files > 0 else f"dim{bg}", "bold" if files > 0 else "dim"))
             else:
                 # Placeholder matching width for alignment
                 if self.summary_detail in ("full", "custom"):
-                    content.append("  Δ-  +   -  -  ", style=mono(f"dim{bg}", "dim"))
+                    content.append("  Δ-  +    -  -   ", style=mono(f"dim{bg}", "dim"))
                 else:
                     content.append("  Δ-", style=mono(f"dim{bg}", "dim"))
 

--- a/tests/unit/test_monitor_daemon_core.py
+++ b/tests/unit/test_monitor_daemon_core.py
@@ -255,38 +255,38 @@ class TestCalculateCostEstimate:
         assert cost == 0.0
 
     def test_input_tokens_only(self):
-        """Input tokens: $15/MTok (Opus 4.5 default)."""
+        """Input tokens: $5/MTok (Opus 4.5 default)."""
         cost = calculate_cost_estimate(
             input_tokens=1_000_000,
             output_tokens=0,
         )
-        assert cost == 15.0
+        assert cost == 5.0
 
     def test_output_tokens_only(self):
-        """Output tokens: $75/MTok (Opus 4.5 default)."""
+        """Output tokens: $25/MTok (Opus 4.5 default)."""
         cost = calculate_cost_estimate(
             input_tokens=0,
             output_tokens=1_000_000,
         )
-        assert cost == 75.0
+        assert cost == 25.0
 
     def test_cache_creation_tokens(self):
-        """Cache creation: $18.75/MTok (Opus 4.5 default)."""
+        """Cache creation: $6.25/MTok (Opus 4.5 default)."""
         cost = calculate_cost_estimate(
             input_tokens=0,
             output_tokens=0,
             cache_creation_tokens=1_000_000,
         )
-        assert cost == 18.75
+        assert cost == 6.25
 
     def test_cache_read_tokens(self):
-        """Cache read: $1.50/MTok (Opus 4.5 default)."""
+        """Cache read: $0.50/MTok (Opus 4.5 default)."""
         cost = calculate_cost_estimate(
             input_tokens=0,
             output_tokens=0,
             cache_read_tokens=1_000_000,
         )
-        assert cost == 1.50
+        assert cost == 0.50
 
     def test_custom_pricing(self):
         """Should use custom pricing when provided."""
@@ -301,12 +301,12 @@ class TestCalculateCostEstimate:
     def test_mixed_tokens(self):
         """Combined token types (Opus 4.5 pricing)."""
         cost = calculate_cost_estimate(
-            input_tokens=500_000,   # $7.50
-            output_tokens=100_000,  # $7.50
-            cache_creation_tokens=200_000,  # $3.75
-            cache_read_tokens=1_000_000,    # $1.50
+            input_tokens=500_000,   # $2.50
+            output_tokens=100_000,  # $2.50
+            cache_creation_tokens=200_000,  # $1.25
+            cache_read_tokens=1_000_000,    # $0.50
         )
-        assert abs(cost - 20.25) < 0.001
+        assert abs(cost - 6.75) < 0.001
 
     def test_realistic_session(self):
         """Realistic session with typical token counts (Opus 4.5 pricing)."""
@@ -314,8 +314,8 @@ class TestCalculateCostEstimate:
             input_tokens=50_000,
             output_tokens=10_000,
         )
-        # 50k * 15/M + 10k * 75/M = 0.75 + 0.75 = 1.50
-        assert abs(cost - 1.50) < 0.001
+        # 50k * 5/M + 10k * 25/M = 0.25 + 0.25 = 0.50
+        assert abs(cost - 0.50) < 0.001
 
 
 class TestCalculateTotalTokens:

--- a/tests/unit/test_tui_helpers.py
+++ b/tests/unit/test_tui_helpers.py
@@ -174,9 +174,11 @@ class TestFormatLineCount:
         assert format_line_count(500) == "500"
 
     def test_thousands(self):
-        """Should format thousands with K (no decimal)."""
-        assert format_line_count(1000) == "1K"
-        assert format_line_count(1500) == "1K"  # Integer division
+        """Should format thousands with K: decimal under 10K, integer above."""
+        assert format_line_count(1000) == "1.0K"
+        assert format_line_count(1500) == "1.5K"
+        assert format_line_count(9999) == "10.0K"
+        assert format_line_count(10000) == "10K"
         assert format_line_count(173000) == "173K"
 
     def test_millions(self):
@@ -234,9 +236,9 @@ class TestCalculatePercentiles:
         times = list(range(1, 101))  # 1 to 100
         mean, p5, p95 = calculate_percentiles(times)
         assert mean == 50.5  # Mean of 1-100
-        # Percentile calculation uses int index: int(100 * 0.05) = 5, times[5] = 6
-        assert p5 == 6  # 5th percentile (index 5 in 1-100 list)
-        assert p95 == 96  # 95th percentile (index 95 in 1-100 list)
+        # Percentile uses int(p * (n-1)): int(0.05 * 99) = 4, times[4] = 5
+        assert p5 == 5  # 5th percentile
+        assert p95 == 95  # 95th percentile (int(0.95 * 99) = 94, times[94] = 95)
 
 
 class TestPresenceStateToChar:


### PR DESCRIPTION
## Summary

- **Pricing defaults**: `calculate_cost_estimate()` had Opus 4.1 defaults ($15/$75/$18.75/$1.50) while `settings.py` had Opus 4.5 ($5/$25/$6.25/$0.50). Docstrings and tests claimed "Opus 4.5" but validated against Opus 4.1 values. Production unaffected (daemon passes explicit prices), but function defaults were 3x wrong.
- **Percentile off-by-one**: `tui_helpers.py` used `int(n * p)` while `web_api.py` correctly used `int(p * (n-1))`. TUI showed p6/p96 instead of p5/p95. Aligned to match the web API formula.
- **format_line_count precision**: Used integer division (`1500 → "1K"`) while `format_tokens()` and `format_cost()` used float division with decimals. Now shows one decimal for values under 10K (`1500 → "1.5K"`), integer for 10K+ to stay within layout width. Git diff display fields widened from `:>4` to `:>5`.

## Test plan

- [x] All 1366 unit tests pass
- [ ] Verify summary line layout looks correct in TUI with real agent data
- [ ] Verify web API and TUI percentiles now agree

🤖 Generated with [Claude Code](https://claude.com/claude-code)