### PR TITLE
Fix context window not shrinking after /clear (#116)

### DIFF
--- a/src/overcode/monitor_daemon.py
+++ b/src/overcode/monitor_daemon.py
@@ -493,6 +493,7 @@ class MonitorDaemon:
                     )
                     if current_id:
                         self.session_manager.add_claude_session_id(session.id, current_id)
+                        self.session_manager.set_active_claude_session_id(session.id, current_id)
                 except (ValueError, TypeError):
                     pass
 


### PR DESCRIPTION
## Summary
- After `/clear`, Claude Code creates a new session ID, but overcode was taking MAX context across all owned sessions — stale high-context sessions dominated the calculation
- Added `active_claude_session_id` field that gets **replaced** (not appended) when a new session is detected, and used only it for context window calculation
- Falls back to MAX-of-owned behavior for backward compatibility when `active_claude_session_id` is not set

## Reproduction
Confirmed live: sent `/clear` to an agent at 68% context → new session started at 10% → overcode still reported 68% because old session dominated the MAX.

## Test plan
- [x] 2 new unit tests: active session overrides MAX, fallback to MAX when no active set
- [x] Full suite passes (1593 passed)
- [ ] Manual verification: `/clear` an agent and confirm context drops in `overcode show --stats-only`

🤖 Generated with [Claude Code](https://claude.com/claude-code)