### PR TITLE
Add hook install/uninstall system

### DIFF
--- a/src/overcode/hook_handler.py
+++ b/src/overcode/hook_handler.py
@@ -1,0 +1,113 @@
+"""Unified hook handler for Claude Code hook events.
+
+A single command (`overcode hook-handler`) handles all hook events.
+It reads stdin JSON from Claude Code, writes state files for hook-based
+status detection, and outputs time-context for UserPromptSubmit events.
+
+Hook registrations (all use the same command):
+    UserPromptSubmit  -> overcode hook-handler
+    PostToolUse       -> overcode hook-handler
+    Stop              -> overcode hook-handler
+    PermissionRequest -> overcode hook-handler
+    SessionEnd        -> overcode hook-handler
+"""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+
+# All hooks that overcode installs
+OVERCODE_HOOKS: list[tuple[str, str]] = [
+    ("UserPromptSubmit", "overcode hook-handler"),
+    ("PostToolUse", "overcode hook-handler"),
+    ("Stop", "overcode hook-handler"),
+    ("PermissionRequest", "overcode hook-handler"),
+    ("SessionEnd", "overcode hook-handler"),
+]
+
+# Legacy hook command to migrate away from
+LEGACY_HOOKS: list[tuple[str, str]] = [
+    ("UserPromptSubmit", "overcode time-context"),
+]
+
+
+def _get_hook_state_path(tmux_session: str, session_name: str) -> Path:
+    """Get the path for a hook state file.
+
+    Returns ~/.overcode/sessions/{tmux_session}/hook_state_{session_name}.json
+    Respects OVERCODE_STATE_DIR environment variable for test isolation.
+    """
+    state_dir = os.environ.get("OVERCODE_STATE_DIR")
+    if state_dir:
+        base = Path(state_dir)
+    else:
+        base = Path.home() / ".overcode" / "sessions"
+    return base / tmux_session / f"hook_state_{session_name}.json"
+
+
+def write_hook_state(
+    event: str,
+    tmux_session: str,
+    session_name: str,
+    tool_name: str | None = None,
+) -> None:
+    """Write hook state JSON for status detection.
+
+    Writes to ~/.overcode/sessions/{tmux_session}/hook_state_{session_name}.json
+    """
+    state_path = _get_hook_state_path(tmux_session, session_name)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+
+    state = {
+        "event": event,
+        "timestamp": time.time(),
+    }
+    if tool_name is not None:
+        state["tool_name"] = tool_name
+
+    state_path.write_text(json.dumps(state))
+
+
+def handle_hook_event() -> None:
+    """Main entry point: read stdin JSON, write state file, output time-context if UserPromptSubmit.
+
+    Called by Claude Code for every hook event. Reads the hook event JSON
+    from stdin, writes a state file for status detection, and for
+    UserPromptSubmit events also outputs time-context to stdout.
+
+    Silent exit (code 0) if env vars missing or stdin is empty/invalid.
+    """
+    session_name = os.environ.get("OVERCODE_SESSION_NAME")
+    tmux_session = os.environ.get("OVERCODE_TMUX_SESSION")
+
+    if not session_name or not tmux_session:
+        return
+
+    # Read stdin JSON
+    try:
+        stdin_data = sys.stdin.read()
+        if not stdin_data.strip():
+            return
+        data = json.loads(stdin_data)
+    except (json.JSONDecodeError, IOError):
+        return
+
+    event = data.get("hook_event_name")
+    if not event:
+        return
+
+    tool_name = data.get("tool_name")
+
+    # Write state file for status detection
+    write_hook_state(event, tmux_session, session_name, tool_name=tool_name)
+
+    # For UserPromptSubmit, also output time-context
+    if event == "UserPromptSubmit":
+        from .time_context import generate_time_context
+
+        line = generate_time_context(tmux_session, session_name)
+        if line:
+            print(line)

--- a/tests/unit/test_hook_handler.py
+++ b/tests/unit/test_hook_handler.py
@@ -1,0 +1,209 @@
+"""Tests for the unified hook handler."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from overcode.hook_handler import (
+    OVERCODE_HOOKS,
+    LEGACY_HOOKS,
+    _get_hook_state_path,
+    write_hook_state,
+    handle_hook_event,
+)
+
+
+class TestConstants:
+
+    def test_overcode_hooks_has_all_events(self):
+        events = [e for e, _ in OVERCODE_HOOKS]
+        assert "UserPromptSubmit" in events
+        assert "PostToolUse" in events
+        assert "Stop" in events
+        assert "PermissionRequest" in events
+        assert "SessionEnd" in events
+
+    def test_all_hooks_use_same_command(self):
+        commands = set(cmd for _, cmd in OVERCODE_HOOKS)
+        assert commands == {"overcode hook-handler"}
+
+    def test_legacy_hooks_has_time_context(self):
+        assert ("UserPromptSubmit", "overcode time-context") in LEGACY_HOOKS
+
+
+class TestGetHookStatePath:
+
+    def test_default_path(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("OVERCODE_STATE_DIR", raising=False)
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        path = _get_hook_state_path("agents", "my-agent")
+        assert path == tmp_path / ".overcode" / "sessions" / "agents" / "hook_state_my-agent.json"
+
+    def test_respects_state_dir(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(tmp_path / "custom"))
+        path = _get_hook_state_path("agents", "my-agent")
+        assert path == tmp_path / "custom" / "agents" / "hook_state_my-agent.json"
+
+
+class TestWriteHookState:
+
+    def test_writes_state_file(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(tmp_path))
+        write_hook_state("Stop", "agents", "my-agent")
+        path = tmp_path / "agents" / "hook_state_my-agent.json"
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert data["event"] == "Stop"
+        assert "timestamp" in data
+        assert "tool_name" not in data
+
+    def test_writes_tool_name(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(tmp_path))
+        write_hook_state("PostToolUse", "agents", "my-agent", tool_name="Bash")
+        path = tmp_path / "agents" / "hook_state_my-agent.json"
+        data = json.loads(path.read_text())
+        assert data["event"] == "PostToolUse"
+        assert data["tool_name"] == "Bash"
+
+    def test_creates_directory(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(tmp_path / "deep" / "nested"))
+        write_hook_state("Stop", "agents", "my-agent")
+        path = tmp_path / "deep" / "nested" / "agents" / "hook_state_my-agent.json"
+        assert path.exists()
+
+
+class TestHandleHookEvent:
+
+    def test_missing_env_vars_silent_exit(self, monkeypatch):
+        monkeypatch.delenv("OVERCODE_SESSION_NAME", raising=False)
+        monkeypatch.delenv("OVERCODE_TMUX_SESSION", raising=False)
+        # Should not raise
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = '{"hook_event_name": "Stop"}'
+            handle_hook_event()
+
+    def test_empty_stdin_silent_exit(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("OVERCODE_SESSION_NAME", "test-agent")
+        monkeypatch.setenv("OVERCODE_TMUX_SESSION", "agents")
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(tmp_path))
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = ""
+            handle_hook_event()
+        # No state file written
+        assert not list(tmp_path.rglob("hook_state_*.json"))
+
+    def test_invalid_stdin_silent_exit(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("OVERCODE_SESSION_NAME", "test-agent")
+        monkeypatch.setenv("OVERCODE_TMUX_SESSION", "agents")
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(tmp_path))
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = "not json{{{}"
+            handle_hook_event()
+        assert not list(tmp_path.rglob("hook_state_*.json"))
+
+    def test_stop_event_writes_state(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("OVERCODE_SESSION_NAME", "test-agent")
+        monkeypatch.setenv("OVERCODE_TMUX_SESSION", "agents")
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(tmp_path))
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = json.dumps({
+                "hook_event_name": "Stop",
+                "session_id": "abc123",
+            })
+            handle_hook_event()
+        state_path = tmp_path / "agents" / "hook_state_test-agent.json"
+        assert state_path.exists()
+        data = json.loads(state_path.read_text())
+        assert data["event"] == "Stop"
+
+    def test_post_tool_use_extracts_tool_name(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("OVERCODE_SESSION_NAME", "test-agent")
+        monkeypatch.setenv("OVERCODE_TMUX_SESSION", "agents")
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(tmp_path))
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = json.dumps({
+                "hook_event_name": "PostToolUse",
+                "tool_name": "Read",
+                "session_id": "abc123",
+            })
+            handle_hook_event()
+        state_path = tmp_path / "agents" / "hook_state_test-agent.json"
+        data = json.loads(state_path.read_text())
+        assert data["event"] == "PostToolUse"
+        assert data["tool_name"] == "Read"
+
+    def test_user_prompt_submit_outputs_time_context(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setenv("OVERCODE_SESSION_NAME", "test-agent")
+        monkeypatch.setenv("OVERCODE_TMUX_SESSION", "agents")
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(tmp_path))
+
+        with patch("sys.stdin") as mock_stdin, \
+             patch("overcode.time_context.generate_time_context", return_value="Clock: 14:00 PST | User: active | Office: yes"):
+            mock_stdin.read.return_value = json.dumps({
+                "hook_event_name": "UserPromptSubmit",
+                "session_id": "abc123",
+            })
+            handle_hook_event()
+
+        captured = capsys.readouterr()
+        assert "Clock: 14:00 PST" in captured.out
+
+        # Also check state file was written
+        state_path = tmp_path / "agents" / "hook_state_test-agent.json"
+        assert state_path.exists()
+
+    def test_user_prompt_submit_empty_time_context(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setenv("OVERCODE_SESSION_NAME", "test-agent")
+        monkeypatch.setenv("OVERCODE_TMUX_SESSION", "agents")
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(tmp_path))
+
+        with patch("sys.stdin") as mock_stdin, \
+             patch("overcode.time_context.generate_time_context", return_value=""):
+            mock_stdin.read.return_value = json.dumps({
+                "hook_event_name": "UserPromptSubmit",
+                "session_id": "abc123",
+            })
+            handle_hook_event()
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_permission_request_writes_state(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("OVERCODE_SESSION_NAME", "test-agent")
+        monkeypatch.setenv("OVERCODE_TMUX_SESSION", "agents")
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(tmp_path))
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = json.dumps({
+                "hook_event_name": "PermissionRequest",
+                "session_id": "abc123",
+            })
+            handle_hook_event()
+        state_path = tmp_path / "agents" / "hook_state_test-agent.json"
+        data = json.loads(state_path.read_text())
+        assert data["event"] == "PermissionRequest"
+
+    def test_session_end_writes_state(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("OVERCODE_SESSION_NAME", "test-agent")
+        monkeypatch.setenv("OVERCODE_TMUX_SESSION", "agents")
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(tmp_path))
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = json.dumps({
+                "hook_event_name": "SessionEnd",
+                "session_id": "abc123",
+            })
+            handle_hook_event()
+        state_path = tmp_path / "agents" / "hook_state_test-agent.json"
+        data = json.loads(state_path.read_text())
+        assert data["event"] == "SessionEnd"
+
+    def test_missing_event_name_silent_exit(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("OVERCODE_SESSION_NAME", "test-agent")
+        monkeypatch.setenv("OVERCODE_TMUX_SESSION", "agents")
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(tmp_path))
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = json.dumps({"session_id": "abc123"})
+            handle_hook_event()
+        assert not list(tmp_path.rglob("hook_state_*.json"))

--- a/tests/unit/test_hooks_cli.py
+++ b/tests/unit/test_hooks_cli.py
@@ -1,0 +1,210 @@
+"""Tests for the hooks CLI commands (install, uninstall, status)."""
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from overcode.cli import app
+from overcode.hook_handler import OVERCODE_HOOKS, LEGACY_HOOKS
+
+
+runner = CliRunner()
+
+
+class TestHooksInstall:
+
+    def test_installs_all_hooks(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        result = runner.invoke(app, ["hooks", "install"])
+        assert result.exit_code == 0
+        assert "Installed" in result.output
+
+        f = tmp_path / ".claude" / "settings.json"
+        assert f.exists()
+        data = json.loads(f.read_text())
+        for event, command in OVERCODE_HOOKS:
+            found = False
+            for entry in data["hooks"].get(event, []):
+                for hook in entry.get("hooks", []):
+                    if hook.get("command") == command:
+                        found = True
+            assert found, f"Hook not found for {event}"
+
+    def test_idempotent(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        # Install once
+        runner.invoke(app, ["hooks", "install"])
+        # Install again
+        result = runner.invoke(app, ["hooks", "install"])
+        assert result.exit_code == 0
+        assert "already installed" in result.output
+
+        # Verify no duplicates
+        f = tmp_path / ".claude" / "settings.json"
+        data = json.loads(f.read_text())
+        for event, command in OVERCODE_HOOKS:
+            count = 0
+            for entry in data["hooks"].get(event, []):
+                for hook in entry.get("hooks", []):
+                    if hook.get("command") == command:
+                        count += 1
+            assert count == 1, f"Duplicate hooks for {event}"
+
+    def test_migrates_legacy_hook(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        # Install legacy hook first
+        settings = {"hooks": {"UserPromptSubmit": [
+            {"matcher": "", "hooks": [{"type": "command", "command": "overcode time-context"}]}
+        ]}}
+        (claude_dir / "settings.json").write_text(json.dumps(settings))
+
+        result = runner.invoke(app, ["hooks", "install"])
+        assert result.exit_code == 0
+        assert "Migrated" in result.output
+
+        # Legacy hook should be gone, new hook present
+        data = json.loads((claude_dir / "settings.json").read_text())
+        for entry in data["hooks"]["UserPromptSubmit"]:
+            for hook in entry.get("hooks", []):
+                assert hook["command"] != "overcode time-context"
+        # New hook should be there
+        found = False
+        for entry in data["hooks"]["UserPromptSubmit"]:
+            for hook in entry.get("hooks", []):
+                if hook["command"] == "overcode hook-handler":
+                    found = True
+        assert found
+
+    def test_project_flag(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["hooks", "install", "--project"])
+        assert result.exit_code == 0
+        assert "project" in result.output
+        f = tmp_path / ".claude" / "settings.json"
+        assert f.exists()
+
+    def test_preserves_existing_settings(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text(json.dumps({"existingKey": True}))
+
+        result = runner.invoke(app, ["hooks", "install"])
+        assert result.exit_code == 0
+        data = json.loads((claude_dir / "settings.json").read_text())
+        assert data["existingKey"] is True
+
+    def test_invalid_json_error(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text("not json{{{")
+        result = runner.invoke(app, ["hooks", "install"])
+        assert result.exit_code == 1
+        assert "Error" in result.output
+
+
+class TestHooksUninstall:
+
+    def test_uninstalls_all_hooks(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        # Install first
+        runner.invoke(app, ["hooks", "install"])
+
+        result = runner.invoke(app, ["hooks", "uninstall"])
+        assert result.exit_code == 0
+        assert "Removed" in result.output
+
+        # Verify hooks are gone
+        f = tmp_path / ".claude" / "settings.json"
+        data = json.loads(f.read_text())
+        assert "hooks" not in data
+
+    def test_uninstall_no_hooks(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text("{}")
+
+        result = runner.invoke(app, ["hooks", "uninstall"])
+        assert result.exit_code == 0
+        assert "No overcode hooks found" in result.output
+
+    def test_uninstall_removes_legacy(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        settings = {"hooks": {"UserPromptSubmit": [
+            {"matcher": "", "hooks": [{"type": "command", "command": "overcode time-context"}]}
+        ]}}
+        (claude_dir / "settings.json").write_text(json.dumps(settings))
+
+        result = runner.invoke(app, ["hooks", "uninstall"])
+        assert result.exit_code == 0
+        assert "Removed" in result.output
+
+        data = json.loads((claude_dir / "settings.json").read_text())
+        assert "hooks" not in data
+
+    def test_uninstall_project_flag(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        # Install project hooks first
+        runner.invoke(app, ["hooks", "install", "--project"])
+        result = runner.invoke(app, ["hooks", "uninstall", "--project"])
+        assert result.exit_code == 0
+        assert "Removed" in result.output
+
+
+class TestHooksStatus:
+
+    def test_shows_installed_hooks(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.chdir(tmp_path)
+        runner.invoke(app, ["hooks", "install"])
+
+        result = runner.invoke(app, ["hooks", "status"])
+        assert result.exit_code == 0
+        assert "UserPromptSubmit" in result.output
+        assert "PostToolUse" in result.output
+        assert "Stop" in result.output
+        assert "PermissionRequest" in result.output
+        assert "SessionEnd" in result.output
+
+    def test_shows_not_installed(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.chdir(tmp_path)
+        # Create settings file so it doesn't short-circuit with "no settings file"
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text("{}")
+
+        result = runner.invoke(app, ["hooks", "status"])
+        assert result.exit_code == 0
+        assert "not installed" in result.output
+
+    def test_shows_legacy_hook_warning(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.chdir(tmp_path)
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        settings = {"hooks": {"UserPromptSubmit": [
+            {"matcher": "", "hooks": [{"type": "command", "command": "overcode time-context"}]}
+        ]}}
+        (claude_dir / "settings.json").write_text(json.dumps(settings))
+
+        result = runner.invoke(app, ["hooks", "status"])
+        assert result.exit_code == 0
+        assert "legacy" in result.output
+        assert "migrate" in result.output.lower()
+
+
+class TestHookHandlerCommand:
+
+    def test_help(self):
+        # hidden=True still allows --help
+        result = runner.invoke(app, ["hook-handler", "--help"])
+        assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- Adds `overcode hooks install/uninstall/status` CLI commands for managing all 5 Claude Code hooks (UserPromptSubmit, PostToolUse, Stop, PermissionRequest, SessionEnd)
- Creates unified `overcode hook-handler` that reads stdin JSON, writes state files for status detection, and outputs time-context for UserPromptSubmit
- Migrates legacy `overcode time-context` hook automatically on install

## Test plan
- [x] 46 new unit tests across 3 test files (hook handler, hooks CLI, claude config)
- [x] Full test suite passes: 1736 passed, 0 failures
- [ ] Manual: `overcode hooks install` → verify `~/.claude/settings.json` has all 5 events
- [ ] Manual: `overcode hooks status` → all green
- [ ] Manual: `overcode hooks uninstall` → settings.json clean
- [ ] Manual: Legacy migration — install old hook first, run `hooks install`, verify migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)