### PR TITLE
Move preview pane update to 250ms fast path

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -822,6 +822,10 @@ class SupervisorTUI(
         if prefs_changed:
             self._save_prefs()
 
+        # Update preview pane on the fast path (250ms) for responsive updates
+        if self.view_mode == "list_preview":
+            self._update_preview()
+
     def _apply_stats_results(self, stats_results: dict, git_diff_results: dict) -> None:
         """Apply slow-path stats results to widgets (runs on main thread)."""
         for widget in self.query(SessionSummary):
@@ -834,10 +838,6 @@ class SupervisorTUI(
                 widget.git_diff_stats = git_diff
             if claude_stats is not None or git_diff is not None:
                 widget.refresh()
-
-        # Update preview pane if in list_preview mode
-        if self.view_mode == "list_preview":
-            self._update_preview()
 
     @work(thread=True, exclusive=True, name="summarizer")
     def _update_summaries_async(self) -> None:


### PR DESCRIPTION
## Summary
- Preview pane was only refreshed from the 5s slow path (`_apply_stats_results`), even though fresh tmux pane content was already being fetched every 250ms by the fast status path
- Moved `_update_preview()` call from `_apply_stats_results` to `_apply_status_results`, reducing preview pane latency from ~1-5s to ~250ms
- No performance concern: `_update_preview()` just copies already-fetched content to a Static widget (no I/O)

## Test plan
- [ ] Open overcode in list+preview mode
- [ ] Press `i` to interact, send a command, verify preview updates within ~250ms
- [ ] Verify scroll position is preserved when manually scrolled up
- [ ] Verify stats (context usage, git diff) still update on the 5s path

🤖 Generated with [Claude Code](https://claude.com/claude-code)