### PR TITLE
Fix #218 alignment bug + split token/cost/budget columns

### DIFF
--- a/src/overcode/summary_groups.py
+++ b/src/overcode/summary_groups.py
@@ -37,7 +37,7 @@ SUMMARY_GROUPS: List[SummaryGroup] = [
     SummaryGroup(
         id="tokens",
         name="Tokens & Cost",
-        fields=["total_tokens", "context_usage", "cost"],
+        fields=["token_count", "cost", "budget"],
         default_enabled=True,
     ),
     SummaryGroup(

--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -922,6 +922,8 @@ class SupervisorTUI(
                         widget.add_class("terminated")
                     else:
                         widget.remove_class("terminated")
+                    # Refresh so column widths (branch, repo) stay aligned (#218)
+                    widget.refresh()
             # Still reorder widgets to handle sort mode changes
             self._reorder_session_widgets(container)
             return

--- a/src/overcode/tui_actions/view.py
+++ b/src/overcode/tui_actions/view.py
@@ -375,7 +375,7 @@ class ViewActionsMixin:
             pass
 
         self.notify(
-            "Showing $ cost" if self.show_cost else "Showing tokens",
+            "Showing cost/budget" if self.show_cost else "Showing token counts",
             severity="information"
         )
 


### PR DESCRIPTION
## Summary
- **Fixes #218**: Column alignment temporarily dropped out of sync when agents switched branches. Root cause: `update_session_widgets()` updated widget session data and recalculated `max_branch_width` but didn't call `widget.refresh()` on the no-structural-changes path, leaving stale rendered content until the next 250ms status cycle.
- **Splits the monolithic `render_tokens()` into three independent columns**: `render_token_count` (Σ123K c@XX%), `render_cost` ($X.XX), and `render_budget` (/$Y.YY). The `$` key now toggles column visibility (hiding two, showing one) rather than swapping content within a single overloaded field.
- Updates tests to cover the three new render functions (1792 pass, 27 skipped).

## Test plan
- [x] `pytest tests/unit/test_summary_columns.py -x -q` — 109 passed
- [x] `pytest tests/unit/ -x -q` — 1792 passed
- [ ] Manual: launch TUI, press `$` to toggle between tokens ↔ cost+budget
- [ ] Manual: set budget with `B`, verify budget column appears/aligns across all agents
- [ ] Manual: have agents on different branches, verify columns stay aligned during branch switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)