### PR TITLE
Fix command bar targeting wrong session (self.focused race)

### DIFF
--- a/src/overcode/tui_actions/session.py
+++ b/src/overcode/tui_actions/session.py
@@ -285,7 +285,7 @@ class SessionActionsMixin:
 
     def action_focus_command_bar(self) -> None:
         """Focus the command bar for input."""
-        from ..tui_widgets import SessionSummary, CommandBar
+        from ..tui_widgets import CommandBar
 
         try:
             cmd_bar = self.query_one("#command-bar", CommandBar)
@@ -293,9 +293,10 @@ class SessionActionsMixin:
             # Show the command bar
             cmd_bar.add_class("visible")
 
-            # Get the currently focused session (if any)
-            focused = self.focused
-            if isinstance(focused, SessionSummary):
+            # Use _get_focused_widget (our own index) not self.focused
+            # (Textual's internal focus) which diverges during DOM reordering
+            focused = self._get_focused_widget()
+            if focused:
                 cmd_bar.set_target(focused.session.name)
             elif not cmd_bar.target_session and self.sessions:
                 # Default to first session if none focused
@@ -310,7 +311,7 @@ class SessionActionsMixin:
 
     def action_focus_standing_orders(self) -> None:
         """Focus the command bar for editing standing orders."""
-        from ..tui_widgets import SessionSummary, CommandBar
+        from ..tui_widgets import CommandBar
 
         try:
             cmd_bar = self.query_one("#command-bar", CommandBar)
@@ -318,9 +319,9 @@ class SessionActionsMixin:
             # Show the command bar
             cmd_bar.add_class("visible")
 
-            # Get the currently focused session (if any)
-            focused = self.focused
-            if isinstance(focused, SessionSummary):
+            # Use _get_focused_widget (our own index) not self.focused
+            focused = self._get_focused_widget()
+            if focused:
                 cmd_bar.set_target(focused.session.name)
                 # Pre-fill with existing standing orders
                 cmd_input = cmd_bar.query_one("#cmd-input", Input)
@@ -341,7 +342,7 @@ class SessionActionsMixin:
 
     def action_focus_human_annotation(self) -> None:
         """Focus input for editing human annotation (#74)."""
-        from ..tui_widgets import SessionSummary, CommandBar
+        from ..tui_widgets import CommandBar
 
         try:
             cmd_bar = self.query_one("#command-bar", CommandBar)
@@ -349,9 +350,9 @@ class SessionActionsMixin:
             # Show the command bar
             cmd_bar.add_class("visible")
 
-            # Get the currently focused session (if any)
-            focused = self.focused
-            if isinstance(focused, SessionSummary):
+            # Use _get_focused_widget (our own index) not self.focused
+            focused = self._get_focused_widget()
+            if focused:
                 cmd_bar.set_target(focused.session.name)
                 # Pre-fill with existing annotation
                 cmd_input = cmd_bar.query_one("#cmd-input", Input)
@@ -372,7 +373,7 @@ class SessionActionsMixin:
 
     def action_edit_agent_value(self) -> None:
         """Focus the command bar for editing agent value (#61)."""
-        from ..tui_widgets import SessionSummary, CommandBar
+        from ..tui_widgets import CommandBar
 
         try:
             cmd_bar = self.query_one("#command-bar", CommandBar)
@@ -380,9 +381,9 @@ class SessionActionsMixin:
             # Show the command bar
             cmd_bar.add_class("visible")
 
-            # Get the currently focused session (if any)
-            focused = self.focused
-            if isinstance(focused, SessionSummary):
+            # Use _get_focused_widget (our own index) not self.focused
+            focused = self._get_focused_widget()
+            if focused:
                 cmd_bar.set_target(focused.session.name)
                 # Pre-fill with existing value
                 cmd_input = cmd_bar.query_one("#cmd-input", Input)
@@ -405,14 +406,15 @@ class SessionActionsMixin:
 
     def action_edit_cost_budget(self) -> None:
         """Focus the command bar for editing cost budget (#173)."""
-        from ..tui_widgets import SessionSummary, CommandBar
+        from ..tui_widgets import CommandBar
 
         try:
             cmd_bar = self.query_one("#command-bar", CommandBar)
             cmd_bar.add_class("visible")
 
-            focused = self.focused
-            if isinstance(focused, SessionSummary):
+            # Use _get_focused_widget (our own index) not self.focused
+            focused = self._get_focused_widget()
+            if focused:
                 cmd_bar.set_target(focused.session.name)
                 cmd_input = cmd_bar.query_one("#cmd-input", Input)
                 current = focused.session.cost_budget_usd
@@ -434,15 +436,15 @@ class SessionActionsMixin:
         1. Enter frequency (e.g., 300, 5m, 1h) or 'off' to disable
         2. Enter instruction to send at each heartbeat
         """
-        from ..tui_widgets import SessionSummary, CommandBar
+        from ..tui_widgets import CommandBar
 
         try:
             cmd_bar = self.query_one("#command-bar", CommandBar)
             cmd_bar.add_class("visible")
 
-            # Get the currently focused session (if any)
-            focused = self.focused
-            if isinstance(focused, SessionSummary):
+            # Use _get_focused_widget (our own index) not self.focused
+            focused = self._get_focused_widget()
+            if focused:
                 cmd_bar.set_target(focused.session.name)
                 # Pre-fill with existing frequency if enabled
                 cmd_input = cmd_bar.query_one("#cmd-input", Input)

--- a/tests/unit/test_tui_actions_session.py
+++ b/tests/unit/test_tui_actions_session.py
@@ -653,12 +653,11 @@ class TestFocusCommandBar:
     def test_opens_and_focuses_command_bar(self):
         """Should show and focus the command bar."""
         from overcode.tui_actions.session import SessionActionsMixin
-        from overcode.tui_widgets import SessionSummary
 
         mock_session = MagicMock()
         mock_session.name = "test-agent"
 
-        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget = MagicMock()
         mock_widget.session = mock_session
 
         mock_input = MagicMock()
@@ -667,7 +666,7 @@ class TestFocusCommandBar:
 
         mock_tui = MagicMock()
         mock_tui.query_one.return_value = mock_cmd_bar
-        mock_tui.focused = mock_widget
+        mock_tui._get_focused_widget.return_value = mock_widget
 
         SessionActionsMixin.action_focus_command_bar(mock_tui)
 
@@ -689,7 +688,7 @@ class TestFocusCommandBar:
 
         mock_tui = MagicMock()
         mock_tui.query_one.return_value = mock_cmd_bar
-        mock_tui.focused = MagicMock()  # Not a SessionSummary
+        mock_tui._get_focused_widget.return_value = None
         mock_tui.sessions = [mock_session]
 
         SessionActionsMixin.action_focus_command_bar(mock_tui)
@@ -714,13 +713,12 @@ class TestFocusStandingOrders:
     def test_opens_command_bar_in_standing_orders_mode(self):
         """Should open command bar with standing_orders mode and pre-fill."""
         from overcode.tui_actions.session import SessionActionsMixin
-        from overcode.tui_widgets import SessionSummary
 
         mock_session = MagicMock()
         mock_session.name = "test-agent"
         mock_session.standing_instructions = "Do the thing"
 
-        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget = MagicMock()
         mock_widget.session = mock_session
 
         mock_input = MagicMock()
@@ -729,7 +727,7 @@ class TestFocusStandingOrders:
 
         mock_tui = MagicMock()
         mock_tui.query_one.return_value = mock_cmd_bar
-        mock_tui.focused = mock_widget
+        mock_tui._get_focused_widget.return_value = mock_widget
 
         SessionActionsMixin.action_focus_standing_orders(mock_tui)
 
@@ -745,13 +743,12 @@ class TestFocusHumanAnnotation:
     def test_opens_command_bar_in_annotation_mode(self):
         """Should open command bar with annotation mode and pre-fill."""
         from overcode.tui_actions.session import SessionActionsMixin
-        from overcode.tui_widgets import SessionSummary
 
         mock_session = MagicMock()
         mock_session.name = "test-agent"
         mock_session.human_annotation = "Needs review"
 
-        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget = MagicMock()
         mock_widget.session = mock_session
 
         mock_input = MagicMock()
@@ -760,7 +757,7 @@ class TestFocusHumanAnnotation:
 
         mock_tui = MagicMock()
         mock_tui.query_one.return_value = mock_cmd_bar
-        mock_tui.focused = mock_widget
+        mock_tui._get_focused_widget.return_value = mock_widget
 
         SessionActionsMixin.action_focus_human_annotation(mock_tui)
 
@@ -775,13 +772,12 @@ class TestEditAgentValue:
     def test_opens_command_bar_in_value_mode(self):
         """Should open command bar with value mode and pre-fill."""
         from overcode.tui_actions.session import SessionActionsMixin
-        from overcode.tui_widgets import SessionSummary
 
         mock_session = MagicMock()
         mock_session.name = "test-agent"
         mock_session.agent_value = 500
 
-        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget = MagicMock()
         mock_widget.session = mock_session
 
         mock_input = MagicMock()
@@ -790,7 +786,7 @@ class TestEditAgentValue:
 
         mock_tui = MagicMock()
         mock_tui.query_one.return_value = mock_cmd_bar
-        mock_tui.focused = mock_widget
+        mock_tui._get_focused_widget.return_value = mock_widget
 
         SessionActionsMixin.action_edit_agent_value(mock_tui)
 
@@ -812,7 +808,7 @@ class TestEditAgentValue:
 
         mock_tui = MagicMock()
         mock_tui.query_one.return_value = mock_cmd_bar
-        mock_tui.focused = MagicMock()  # Not a SessionSummary
+        mock_tui._get_focused_widget.return_value = None
         mock_tui.sessions = [mock_session]
 
         SessionActionsMixin.action_edit_agent_value(mock_tui)
@@ -827,14 +823,13 @@ class TestConfigureHeartbeat:
     def test_opens_command_bar_in_heartbeat_freq_mode_enabled(self):
         """Should pre-fill with existing frequency when heartbeat is enabled."""
         from overcode.tui_actions.session import SessionActionsMixin
-        from overcode.tui_widgets import SessionSummary
 
         mock_session = MagicMock()
         mock_session.name = "test-agent"
         mock_session.heartbeat_enabled = True
         mock_session.heartbeat_frequency_seconds = 600
 
-        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget = MagicMock()
         mock_widget.session = mock_session
 
         mock_input = MagicMock()
@@ -843,7 +838,7 @@ class TestConfigureHeartbeat:
 
         mock_tui = MagicMock()
         mock_tui.query_one.return_value = mock_cmd_bar
-        mock_tui.focused = mock_widget
+        mock_tui._get_focused_widget.return_value = mock_widget
 
         SessionActionsMixin.action_configure_heartbeat(mock_tui)
 
@@ -854,13 +849,12 @@ class TestConfigureHeartbeat:
     def test_opens_command_bar_in_heartbeat_freq_mode_disabled(self):
         """Should pre-fill with 300 (default) when heartbeat is disabled."""
         from overcode.tui_actions.session import SessionActionsMixin
-        from overcode.tui_widgets import SessionSummary
 
         mock_session = MagicMock()
         mock_session.name = "test-agent"
         mock_session.heartbeat_enabled = False
 
-        mock_widget = MagicMock(spec=SessionSummary)
+        mock_widget = MagicMock()
         mock_widget.session = mock_session
 
         mock_input = MagicMock()
@@ -869,7 +863,7 @@ class TestConfigureHeartbeat:
 
         mock_tui = MagicMock()
         mock_tui.query_one.return_value = mock_cmd_bar
-        mock_tui.focused = mock_widget
+        mock_tui._get_focused_widget.return_value = mock_widget
 
         SessionActionsMixin.action_configure_heartbeat(mock_tui)
 


### PR DESCRIPTION
## Summary
- All 6 command-bar-opening actions (`i`, standing orders, annotation, agent value, cost budget, heartbeat) used Textual's `self.focused` to determine the target session, which can diverge from the visually highlighted row during DOM reordering and async status updates
- Replaced with `self._get_focused_widget()` which uses our own `focused_session_index` — the same pattern already used by `refresh_sessions()` and `_update_preview()`

## Test plan
- [x] All 1742 unit tests pass
- [ ] Manual: open TUI with multiple sessions, navigate with j/k, press `i` — verify command bar targets the highlighted session
- [ ] Manual: trigger sort reorder while sessions are visible, then press `i` — verify correct targeting

🤖 Generated with [Claude Code](https://claude.com/claude-code)