### PR TITLE
Prevent agent with active heartbeat from sleeping (#219)

### DIFF
--- a/src/overcode/tui_actions/session.py
+++ b/src/overcode/tui_actions/session.py
@@ -52,6 +52,11 @@ class SessionActionsMixin:
             self.notify("Cannot put a running agent to sleep", severity="warning")
             return
 
+        # Prevent putting an agent with heartbeat enabled to sleep (#219)
+        if new_asleep_state and session.heartbeat_enabled and not session.heartbeat_paused:
+            self.notify("Cannot sleep agent with active heartbeat — disable heartbeat first", severity="warning")
+            return
+
         # Update the session in the session manager
         self.session_manager.update_session(session.id, is_asleep=new_asleep_state)
 


### PR DESCRIPTION
## Summary
- Adds guard in `action_toggle_sleep` to prevent putting agents with active (non-paused) heartbeat to sleep
- Sleeping a heartbeat agent creates a conflicting state since heartbeat would auto-resume
- User is notified to disable heartbeat first

Closes #219

## Test plan
- [ ] Focus an agent with heartbeat enabled, press `z` — should show warning
- [ ] Disable heartbeat, press `z` again — should sleep normally
- [ ] Paused heartbeat should also allow sleeping

🤖 Generated with [Claude Code](https://claude.com/claude-code)