### PR TITLE
Signal daemon on heartbeat changes for immediate status update (#212)

### DIFF
--- a/src/overcode/cli.py
+++ b/src/overcode/cli.py
@@ -759,6 +759,12 @@ def instruct(
             rprint(f"[dim]Tip: Use 'overcode presets' to see available presets[/dim]")
 
 
+def _signal_heartbeat_change(session: str) -> None:
+    """Wake the monitor daemon so heartbeat status updates immediately (#212)."""
+    from .settings import signal_activity
+    signal_activity(session)
+
+
 @app.command()
 def heartbeat(
     name: Annotated[str, typer.Argument(help="Name of agent")],
@@ -851,6 +857,7 @@ def heartbeat(
             heartbeat_paused=False,
             heartbeat_instruction="",
         )
+        _signal_heartbeat_change(session)
         rprint(f"[green]✓ Heartbeat disabled for {name}[/green]")
         return
 
@@ -860,6 +867,7 @@ def heartbeat(
             rprint(f"[yellow]Heartbeat is not enabled for {name}[/yellow]")
             return
         manager.update_session(agent.id, heartbeat_paused=True)
+        _signal_heartbeat_change(session)
         rprint(f"[green]✓ Heartbeat paused for {name}[/green]")
         return
 
@@ -869,6 +877,7 @@ def heartbeat(
             rprint(f"[yellow]Heartbeat is not enabled for {name}[/yellow]")
             return
         manager.update_session(agent.id, heartbeat_paused=False)
+        _signal_heartbeat_change(session)
         rprint(f"[green]✓ Heartbeat resumed for {name}[/green]")
         return
 
@@ -886,6 +895,7 @@ def heartbeat(
             heartbeat_frequency_seconds=final_freq,
             heartbeat_instruction=instruction,
         )
+        _signal_heartbeat_change(session)
         rprint(f"[green]✓ Heartbeat enabled for {name}[/green]")
         rprint(f"  Frequency: {format_duration(final_freq)}")
         rprint(f"  Instruction: {instruction}")
@@ -900,6 +910,7 @@ def heartbeat(
 
     if updates:
         manager.update_session(agent.id, **updates)
+        _signal_heartbeat_change(session)
         rprint(f"[green]✓ Heartbeat config updated for {name}[/green]")
         if freq_seconds:
             rprint(f"  Frequency: {format_duration(freq_seconds)}")

--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -1284,6 +1284,9 @@ class SupervisorTUI(
             heartbeat_instruction=message.instruction,
         )
 
+        # Wake daemon so status updates immediately (#212)
+        signal_activity(self.tmux_session)
+
         if message.enabled:
             freq_str = format_duration(message.frequency)
             self.notify(f"Heartbeat enabled: every {freq_str}", severity="information")


### PR DESCRIPTION
## Summary
- Adds activity signal after heartbeat enable/disable/pause/resume in both CLI and TUI
- Monitor daemon wakes from slow/idle interval and picks up the heartbeat config change immediately
- Status display now transitions from red to yellow heart without waiting for next poll cycle

Closes #212

## Test plan
- [ ] Enable heartbeat via CLI (`overcode heartbeat agent -e -f 5m -i "check"`) — status should change to yellow heart within ~10s
- [ ] Enable heartbeat via TUI (H key) — same immediate update
- [ ] Disable heartbeat — status should revert to red immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)