### PR TITLE
Add `overcode annotate` CLI command (#223)

### DIFF
--- a/src/overcode/cli.py
+++ b/src/overcode/cli.py
@@ -292,6 +292,40 @@ def set_budget(
 
 
 @app.command()
+def annotate(
+    name: Annotated[str, typer.Argument(help="Name of agent")],
+    text: Annotated[
+        Optional[List[str]], typer.Argument(help="Annotation text (omit to clear)")
+    ] = None,
+    session: SessionOption = "agents",
+):
+    """Set or clear a human annotation on an agent (#223).
+
+    Allows programmatic annotation of agents so scripts and other tools
+    can communicate status to the overcode TUI.
+
+    Examples:
+        overcode annotate my-agent "Working on auth module"
+        overcode annotate my-agent Building the API layer
+        overcode annotate my-agent                           # Clear annotation
+    """
+    from .session_manager import SessionManager
+
+    manager = SessionManager()
+    agent = manager.get_session_by_name(name)
+    if not agent:
+        rprint(f"[red]Error: Agent '{name}' not found[/red]")
+        raise typer.Exit(code=1)
+
+    annotation = " ".join(text) if text else ""
+    manager.set_human_annotation(agent.id, annotation)
+    if annotation:
+        rprint(f"[green]✓ Annotation set for {name}:[/green] {annotation}")
+    else:
+        rprint(f"[green]✓ Annotation cleared for {name}[/green]")
+
+
+@app.command()
 def send(
     name: Annotated[str, typer.Argument(help="Name of agent")],
     text: Annotated[


### PR DESCRIPTION
## Summary
- Adds `overcode annotate <agent> [text...]` command to set/clear human annotations
- Enables programmatic annotation from scripts, hooks, and automation tools
- Supports multi-word text without quotes: `overcode annotate my-agent Working on auth`
- Omitting text clears the annotation: `overcode annotate my-agent`

Closes #223

## Test plan
- [ ] `overcode annotate agent "test annotation"` — sets annotation, visible in TUI
- [ ] `overcode annotate agent Working on feature` — multi-word without quotes works
- [ ] `overcode annotate agent` — clears annotation
- [ ] `overcode annotate nonexistent` — shows error for unknown agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)