### PR TITLE
Fix --bare attach: use linked session to isolate options

### DIFF
--- a/src/overcode/implementations.py
+++ b/src/overcode/implementations.py
@@ -231,18 +231,39 @@ class RealTmux:
             return []
 
     def attach(self, session: str, window: Optional[int] = None, bare: bool = False) -> None:
-        target = f"{session}:={window}" if window is not None else session
         if bare:
-            os.execlp(
-                "tmux", "tmux",
-                "attach-session", "-t", target,
-                ";", "set", "status", "off",
-                ";", "set", "mouse", "off",
-                ";", "set", "prefix", "None",
-                ";", "set", "prefix2", "None",
-            )
+            self._attach_bare(session, window)
         else:
+            target = f"{session}:={window}" if window is not None else session
             os.execlp("tmux", "tmux", "attach-session", "-t", target)
+
+    def _attach_bare(self, session: str, window: int) -> None:
+        """Create a linked session with stripped chrome and attach to it."""
+        import subprocess
+
+        bare_session = f"bare-{session}-{window}"
+
+        subprocess.run(
+            ["tmux", "kill-session", "-t", bare_session],
+            capture_output=True,
+        )
+
+        result = subprocess.run(
+            ["tmux", "new-session", "-d", "-s", bare_session, "-t", session],
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            return
+
+        for cmd in [
+            ["tmux", "set", "-t", bare_session, "status", "off"],
+            ["tmux", "set", "-t", bare_session, "mouse", "off"],
+            ["tmux", "set", "-t", bare_session, "destroy-unattached", "on"],
+            ["tmux", "select-window", "-t", f"{bare_session}:={window}"],
+        ]:
+            subprocess.run(cmd, capture_output=True)
+
+        os.execlp("tmux", "tmux", "attach-session", "-t", bare_session)
 
     def select_window(self, session: str, window: int) -> bool:
         """Select a window in a tmux session (for external pane sync)."""

--- a/src/overcode/tmux_manager.py
+++ b/src/overcode/tmux_manager.py
@@ -164,23 +164,55 @@ class TmuxManager:
 
         Args:
             window: optional window index to target
-            bare: if True, strip tmux chrome for embedding in other terminals
+            bare: if True, create a linked session with tmux chrome stripped,
+                  isolated from other clients attached to the main session
         """
         if self._tmux:
             self._tmux.attach(self.session_name, window=window, bare=bare)
             return
-        target = f"{self.session_name}:={window}" if window is not None else self.session_name
         if bare:
-            os.execlp(
-                "tmux", "tmux",
-                "attach-session", "-t", target,
-                ";", "set", "status", "off",
-                ";", "set", "mouse", "off",
-                ";", "set", "prefix", "None",
-                ";", "set", "prefix2", "None",
-            )
+            self._attach_bare(window)
         else:
+            target = f"{self.session_name}:={window}" if window is not None else self.session_name
             os.execlp("tmux", "tmux", "attach-session", "-t", target)
+
+    def _attach_bare(self, window: int):
+        """Create a linked session with stripped chrome and attach to it.
+
+        Uses a grouped session (new-session -t) so options are isolated
+        from the main session. Sets destroy-unattached so the linked
+        session is cleaned up when the terminal closes.
+        """
+        import subprocess
+
+        bare_session = f"bare-{self.session_name}-{window}"
+
+        # Kill any stale bare session with the same name
+        subprocess.run(
+            ["tmux", "kill-session", "-t", bare_session],
+            capture_output=True,
+        )
+
+        # Create linked session sharing the same window group
+        result = subprocess.run(
+            ["tmux", "new-session", "-d", "-s", bare_session, "-t", self.session_name],
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            print(f"Failed to create bare session: {result.stderr.decode().strip()}")
+            return
+
+        # Configure the linked session (isolated from main session)
+        for cmd in [
+            ["tmux", "set", "-t", bare_session, "status", "off"],
+            ["tmux", "set", "-t", bare_session, "mouse", "off"],
+            ["tmux", "set", "-t", bare_session, "destroy-unattached", "on"],
+            ["tmux", "select-window", "-t", f"{bare_session}:={window}"],
+        ]:
+            subprocess.run(cmd, capture_output=True)
+
+        # Attach (replaces process)
+        os.execlp("tmux", "tmux", "attach-session", "-t", bare_session)
 
     def list_windows(self) -> List[Dict[str, Any]]:
         """List all windows in the session.


### PR DESCRIPTION
## Summary
- Fixes a bug where `overcode attach --bare` set tmux options (status, mouse, prefix) at the **session level**, affecting all clients attached to the session
- Now creates a grouped/linked tmux session (`new-session -t`) with its own isolated options
- The linked session auto-destroys when the client detaches (`destroy-unattached`)
- `Ctrl-b d` works for detaching (no longer nukes the prefix key)

Follow-up fix for #43 / #248.

## Test plan
- [ ] `overcode attach --bare agent` creates a `bare-agents-{window}` session
- [ ] Other tmux clients attached to `agents` are unaffected
- [ ] Closing the bare terminal cleans up the linked session
- [ ] `Ctrl-b d` detaches and cleans up the linked session
- [ ] 200 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)