### PR TITLE
Fix idle plan-mode sessions falsely detected as waiting for approval

### DIFF
--- a/src/overcode/status_detector.py
+++ b/src/overcode/status_detector.py
@@ -172,7 +172,10 @@ class PollingStatusDetector:
         # Check for approval waiting state (#22)
         # Only reached when content is NOT changing, so plan mode correctly shows
         # orange only when Claude has stopped and is waiting for plan approval (#214).
-        if self._matches_approval_patterns(last_few):
+        # Guard: require Claude output (⏺) in content — without it, "plan mode"
+        # is just UI chrome from the startup banner, not a plan awaiting approval.
+        has_claude_output = any(line.strip().startswith('⏺') for line in lines)
+        if has_claude_output and self._matches_approval_patterns(last_few):
             return self.STATUS_WAITING_APPROVAL, "Waiting for plan/decision approval", content
 
         # Check for command menu display (slash command autocomplete)

--- a/src/overcode/status_patterns.py
+++ b/src/overcode/status_patterns.py
@@ -127,6 +127,7 @@ class StatusPatterns:
     # Lines starting with these are UI chrome, not Claude output.
     status_bar_prefixes: List[str] = field(default_factory=lambda: [
         "⏵⏵",  # Status bar indicator (e.g., "⏵⏵ bypass permissions on")
+        "⏸",   # Plan mode status bar (e.g., "⏸ plan mode on (shift+tab to cycle)")
     ])
 
     # Command menu pattern - regex pattern for slash command menu lines

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -347,6 +347,31 @@ PANE_CONTENT_NARRATIVE_ERROR_PATTERNS = """
 
 
 # Spawn failure: claude command not found (bash style)
+# Plan mode: idle session — captured from real `claude --permission-mode plan`
+# "plan mode" appears in the ⏸ status bar line, not the banner
+PANE_CONTENT_PLAN_MODE_IDLE = """
+           Claude Code v2.1.41
+ ▐▛███▜▌   Opus 4.6 · Claude Max
+▝▜█████▛▘  ~/Code/overcode2
+  ▘▘ ▝▝    Opus 4.6 is here
+
+────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────
+  ⏸ plan mode on (shift+tab to cycle) · PR #257
+"""
+
+# Plan approval: Claude has produced a plan and is waiting for user to approve
+PANE_CONTENT_PLAN_APPROVAL = """
+⏺ I've analyzed the codebase and written my plan. Please review the plan
+  and let me know if you'd like to approve this plan or make changes.
+
+────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────
+  ⏸ plan mode on (shift+tab to cycle)
+"""
+
 PANE_CONTENT_SPAWN_FAILED_BASH = """
 Last login: Thu Jan 23 10:00:00 on ttys001
 user@hostname ~ % claude code


### PR DESCRIPTION
## Summary
- Fresh Claude Code sessions in plan mode showed orange (waiting for approval) instead of red (waiting for user input)
- The `"plan mode"` text in Claude Code's startup banner matched `approval_patterns`
- Added a guard requiring Claude output (`⏺`) in pane content before triggering approval detection — without it, "plan mode" is just UI chrome

## Test plan
- [x] New test: idle plan-mode session → `STATUS_WAITING_USER`
- [x] New test: genuine plan approval with Claude output → `STATUS_WAITING_APPROVAL`
- [x] New test: approval text without `⏺` output → not `STATUS_WAITING_APPROVAL`
- [x] Full unit suite passes (1851 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)