### PR TITLE
Fix daemon/TUI status desync for terminated sessions

### DIFF
--- a/src/overcode/status_detector.py
+++ b/src/overcode/status_detector.py
@@ -98,8 +98,10 @@ class PollingStatusDetector:
         """
         content = self.get_pane_content(session.tmux_window)
 
+        if content is None:
+            return self.STATUS_TERMINATED, "Window no longer exists", ""
         if not content:
-            return self.STATUS_WAITING_USER, "Unable to read pane", ""
+            return self.STATUS_WAITING_USER, "Empty pane", ""
 
         # Strip ANSI escape sequences for pattern matching
         # The raw content (with colors) is returned for display, but pattern

--- a/tests/unit/test_status_detector.py
+++ b/tests/unit/test_status_detector.py
@@ -333,7 +333,6 @@ class TestStatusDetectorEdgeCases:
 
     def test_handles_empty_pane(self):
         """Empty pane content should return waiting_user"""
-        # Empty string returns None from capture_pane (nothing to capture)
         mock_tmux = create_mock_tmux_with_content("agents", 1, "")
         detector = StatusDetector("agents", tmux=mock_tmux)
         session = create_mock_session(tmux_window=1)
@@ -341,22 +340,21 @@ class TestStatusDetectorEdgeCases:
         status, activity, _ = detector.detect_status(session)
 
         assert status == StatusDetector.STATUS_WAITING_USER
-        # Empty content returns "Unable to read pane" because capture returns None
-        assert "Unable to read pane" in activity or "No output" in activity
+        assert "Empty pane" in activity
 
     def test_handles_missing_pane(self):
-        """Missing pane should return waiting_user with error message"""
+        """Missing pane (window gone) should return terminated"""
         mock_tmux = MockTmux()
         mock_tmux.new_session("agents")
-        # Don't create window 1
+        # Don't create window 1 — simulates a killed tmux window
 
         detector = StatusDetector("agents", tmux=mock_tmux)
         session = create_mock_session(tmux_window=1)
 
         status, activity, _ = detector.detect_status(session)
 
-        assert status == StatusDetector.STATUS_WAITING_USER
-        assert "Unable to read pane" in activity
+        assert status == StatusDetector.STATUS_TERMINATED
+        assert "Window no longer exists" in activity
 
     def test_handles_whitespace_only_content(self):
         """Whitespace-only content should be treated as no output"""


### PR DESCRIPTION
## Summary
- `detect_status()` returned `waiting_user` when a tmux window was gone because `if not content` conflated `None` (window missing) with `""` (empty pane). The daemon had no guard, so it logged `waiting_user` to CSV history, causing the timeline to show red instead of `x` for terminated sessions.
- Three layered fixes: (1) split `None` vs `""` in the polling detector, (2) daemon skips `detect_status` for already-terminated/done sessions, (3) daemon persists terminated status to sessions.json on first detection.

## Test plan
- [x] `test_status_detector.py` — 39 tests pass (updated `test_handles_missing_pane` → expects TERMINATED, `test_handles_empty_pane` → expects "Empty pane")
- [x] `test_status_detector_contract.py` — 21 tests pass (contract updated, hook-with-state override added)
- [x] `test_monitor_daemon.py` — 50 tests pass (new guard + persistence tests)
- [x] Full unit suite — 1891 passed, 27 skipped
- [ ] Manual: launch TUI, kill a tmux window, verify both main display and timeline show terminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)