### PR TITLE
Add 5-level user presence activity tracking

### DIFF
--- a/src/overcode/data_export.py
+++ b/src/overcode/data_export.py
@@ -230,7 +230,7 @@ def _build_presence_records():
         records.append({
             "timestamp": ts.isoformat() if isinstance(ts, datetime) else str(ts),
             "state": state,
-            "state_name": {1: "locked", 2: "inactive", 3: "active"}.get(state, "unknown"),
+            "state_name": {0: "asleep", 1: "locked", 2: "idle", 3: "active", 4: "tui_active"}.get(state, "unknown"),
         })
 
     return records

--- a/src/overcode/monitor_daemon_state.py
+++ b/src/overcode/monitor_daemon_state.py
@@ -241,7 +241,7 @@ class MonitorDaemonState:
 
     # Presence state (optional, macOS only)
     presence_available: bool = False
-    presence_state: Optional[int] = None  # 1=locked/sleep, 2=inactive, 3=active
+    presence_state: Optional[int] = None  # 0=asleep, 1=locked, 2=idle, 3=active, 4=tui_active
     presence_idle_seconds: Optional[float] = None
 
     # Summary metrics (computed from sessions)

--- a/src/overcode/settings.py
+++ b/src/overcode/settings.py
@@ -383,6 +383,26 @@ def get_default_tmux_session() -> str:
 # TUI Preferences (persisted between launches)
 # =============================================================================
 
+def get_tui_heartbeat_path(session: str) -> Path:
+    """Get TUI heartbeat file path for a specific session."""
+    return get_session_dir(session) / "tui_heartbeat"
+
+
+def write_tui_heartbeat(session: str) -> None:
+    """Write current ISO timestamp to TUI heartbeat file.
+
+    Called by TUI on keypress (throttled) so the monitor daemon
+    can distinguish TUI-active from computer-active presence.
+    """
+    from datetime import datetime
+    heartbeat_path = get_tui_heartbeat_path(session)
+    try:
+        heartbeat_path.parent.mkdir(parents=True, exist_ok=True)
+        heartbeat_path.write_text(datetime.now().isoformat())
+    except OSError:
+        pass  # Best effort
+
+
 def get_tui_preferences_path(session: str) -> Path:
     """Get TUI preferences file path for a specific session."""
     return get_session_dir(session) / "tui_preferences.json"

--- a/src/overcode/status_constants.py
+++ b/src/overcode/status_constants.py
@@ -64,9 +64,11 @@ DAEMON_STATUS_NO_AGENTS = "no_agents"
 # Presence State Values
 # =============================================================================
 
+PRESENCE_ASLEEP = 0
 PRESENCE_LOCKED = 1
-PRESENCE_INACTIVE = 2
+PRESENCE_IDLE = 2       # Was PRESENCE_INACTIVE
 PRESENCE_ACTIVE = 3
+PRESENCE_TUI_ACTIVE = 4
 
 
 # =============================================================================
@@ -166,9 +168,11 @@ def get_agent_timeline_char(status: str) -> str:
 
 
 PRESENCE_TIMELINE_CHARS = {
+    PRESENCE_ASLEEP: " ",
     PRESENCE_LOCKED: "░",
-    PRESENCE_INACTIVE: "▒",
-    PRESENCE_ACTIVE: "█",
+    PRESENCE_IDLE: "▒",
+    PRESENCE_ACTIVE: "▓",
+    PRESENCE_TUI_ACTIVE: "█",
 }
 
 
@@ -182,9 +186,11 @@ def get_presence_timeline_char(state: int) -> str:
 # =============================================================================
 
 PRESENCE_COLORS = {
+    PRESENCE_ASLEEP: "#1a1a2e",
     PRESENCE_LOCKED: "red",
-    PRESENCE_INACTIVE: "yellow",
-    PRESENCE_ACTIVE: "green",
+    PRESENCE_IDLE: "orange1",
+    PRESENCE_ACTIVE: "yellow",
+    PRESENCE_TUI_ACTIVE: "green",
 }
 
 

--- a/src/overcode/time_context.py
+++ b/src/overcode/time_context.py
@@ -45,12 +45,12 @@ def format_presence(presence_state: Optional[int]) -> str:
     """Format user presence state from monitor daemon.
 
     Args:
-        presence_state: 1=locked/sleep, 2=inactive, 3=active, None=unknown
+        presence_state: 0=asleep, 1=locked, 2=idle, 3=active, 4=tui_active, None=unknown
 
     Returns:
-        One of: 'active', 'inactive', 'locked', 'unknown'
+        One of: 'asleep', 'locked', 'idle', 'active', 'tui_active', 'unknown'
     """
-    mapping = {1: "locked", 2: "inactive", 3: "active"}
+    mapping = {0: "asleep", 1: "locked", 2: "idle", 3: "active", 4: "tui_active"}
     return mapping.get(presence_state, "unknown")
 
 

--- a/src/overcode/tui_helpers.py
+++ b/src/overcode/tui_helpers.py
@@ -70,7 +70,7 @@ def presence_state_to_char(state: int) -> str:
     """Convert presence state to timeline character.
 
     Args:
-        state: 1=locked/sleep, 2=inactive, 3=active
+        state: 0=asleep, 1=locked, 2=idle, 3=active, 4=tui_active
 
     Returns:
         Block character for timeline visualization
@@ -248,7 +248,7 @@ def get_presence_color(state: int) -> str:
     """Get color for presence state.
 
     Args:
-        state: Presence state (1=locked/sleep, 2=inactive, 3=active)
+        state: Presence state (0=asleep, 1=locked, 2=idle, 3=active, 4=tui_active)
 
     Returns:
         Color name for Rich styling

--- a/src/overcode/tui_render.py
+++ b/src/overcode/tui_render.py
@@ -217,8 +217,8 @@ def render_presence_indicator(
     """
     content = Text()
 
-    state_icons = {1: "🔒", 2: "💤", 3: "👤"}
-    state_colors = {1: "red", 2: "yellow", 3: "green"}
+    state_icons = {0: "⏻", 1: "🔒", 2: "🧘", 3: "🚶", 4: "🏃"}
+    state_colors = {0: "#1a1a2e", 1: "red", 2: "orange1", 3: "yellow", 4: "green"}
 
     icon = state_icons.get(presence_state, "?")
     color = state_colors.get(presence_state, "dim")

--- a/src/overcode/tui_widgets/daemon_status_bar.py
+++ b/src/overcode/tui_widgets/daemon_status_bar.py
@@ -280,8 +280,8 @@ class DaemonStatusBar(Static):
             state = self.monitor_state.presence_state
             idle = self.monitor_state.presence_idle_seconds or 0
 
-            state_names = {1: "🔒", 2: "💤", 3: "👤"}
-            state_colors = {1: "red", 2: "yellow", 3: "green"}
+            state_names = {0: "⏻", 1: "🔒", 2: "🧘", 3: "🚶", 4: "🏃"}
+            state_colors = {0: "#1a1a2e", 1: "red", 2: "orange1", 3: "yellow", 4: "green"}
 
             icon = state_names.get(state, "?")
             color = state_colors.get(state, "dim")

--- a/src/overcode/tui_widgets/status_timeline.py
+++ b/src/overcode/tui_widgets/status_timeline.py
@@ -28,7 +28,7 @@ class StatusTimeline(Static):
     """Widget displaying historical status timelines for user presence and agents.
 
     Shows the last N hours with each character representing a time slice.
-    - User presence: green=active, yellow=inactive, red/gray=locked/away
+    - User presence: green=TUI active, yellow=active, orange=idle, red=locked
     - Agent status: green=running, red=waiting, grey=terminated
 
     Timeline hours configurable via ~/.overcode/config.yaml (timeline.hours).
@@ -274,15 +274,15 @@ class StatusTimeline(Static):
         # Legend (combined on one line to save space)
         content.append(f"  {'Legend:':<14} ", style="dim")
         content.append("█", style="green")
-        content.append("active/running ", style="dim")
+        content.append("TUI/running ", style="dim")
+        content.append("▓", style="yellow")
+        content.append("active ", style="dim")
         content.append("💚", style="")
-        content.append("heartbeat start ", style="dim")
-        content.append("▒", style="yellow")
-        content.append("inactive ", style="dim")
+        content.append("heartbeat ", style="dim")
+        content.append("▒", style="orange1")
+        content.append("idle ", style="dim")
         content.append("░", style="red")
-        content.append("waiting/away ", style="dim")
-        content.append("░", style="dim")
-        content.append("asleep ", style="dim")
+        content.append("locked ", style="dim")
         content.append("×", style="dim")
         content.append("terminated", style="dim")
 

--- a/tests/unit/test_data_export.py
+++ b/tests/unit/test_data_export.py
@@ -435,8 +435,8 @@ class TestBuildPresenceRecordsStateMapping:
             assert len(records) == 1
             assert records[0]["state_name"] == "unknown"
 
-    def test_inactive_state_maps_correctly(self):
-        """State 2 should map to 'inactive'."""
+    def test_idle_state_maps_correctly(self):
+        """State 2 should map to 'idle'."""
         with patch("overcode.data_export.read_presence_history") as mock_read:
             mock_read.return_value = [
                 (datetime(2024, 1, 1, 12, 0), 2),
@@ -444,7 +444,7 @@ class TestBuildPresenceRecordsStateMapping:
             records = _build_presence_records()
 
             assert len(records) == 1
-            assert records[0]["state_name"] == "inactive"
+            assert records[0]["state_name"] == "idle"
 
     def test_locked_state_maps_correctly(self):
         """State 1 should map to 'locked'."""
@@ -464,14 +464,14 @@ class TestBuildPresenceRecordsStateMapping:
             records = _build_presence_records()
             assert records[0]["state_name"] == "active"
 
-    def test_zero_state_maps_to_unknown(self):
-        """State 0 is not in the mapping, should be 'unknown'."""
+    def test_zero_state_maps_to_asleep(self):
+        """State 0 maps to 'asleep'."""
         with patch("overcode.data_export.read_presence_history") as mock_read:
             mock_read.return_value = [
                 (datetime(2024, 1, 1, 12, 0), 0),
             ]
             records = _build_presence_records()
-            assert records[0]["state_name"] == "unknown"
+            assert records[0]["state_name"] == "asleep"
 
 
 class TestExportToParquet:

--- a/tests/unit/test_status_timeline.py
+++ b/tests/unit/test_status_timeline.py
@@ -299,10 +299,10 @@ class TestStatusTimelineRender:
             with patch.object(type(widget), 'label_width', new_callable=PropertyMock, return_value=6):
                 result = widget.render()
         plain = result.plain
-        assert "active/running" in plain
-        assert "waiting/away" in plain
+        assert "TUI/running" in plain
+        assert "locked" in plain
         assert "terminated" in plain
-        assert "heartbeat start" in plain
+        assert "heartbeat" in plain
 
     def test_render_with_baseline_marker(self):
         widget = _make_bare_timeline(sessions=[], timeline_hours=3.0)

--- a/tests/unit/test_time_context.py
+++ b/tests/unit/test_time_context.py
@@ -79,8 +79,8 @@ class TestFormatPresence:
     def test_active(self):
         assert format_presence(3) == "active"
 
-    def test_inactive(self):
-        assert format_presence(2) == "inactive"
+    def test_idle(self):
+        assert format_presence(2) == "idle"
 
     def test_locked(self):
         assert format_presence(1) == "locked"
@@ -357,7 +357,7 @@ class TestGenerateTimeContext:
         now = datetime(2025, 1, 15, 14, 0, 0)
         result = generate_time_context("agents", "my-agent", now=now, config=config)
 
-        assert "User: inactive" in result
+        assert "User: idle" in result
         assert "Uptime" not in result
 
     def test_with_heartbeat(self, tmp_path, monkeypatch):

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -340,8 +340,12 @@ class TestPresenceStateToChar:
         assert presence_state_to_char(2) == "▒"
 
     def test_active_state(self):
-        """State 3 (active) returns full block"""
-        assert presence_state_to_char(3) == "█"
+        """State 3 (active) returns dense shade"""
+        assert presence_state_to_char(3) == "▓"
+
+    def test_tui_active_state(self):
+        """State 4 (TUI active) returns full block"""
+        assert presence_state_to_char(4) == "█"
 
     def test_unknown_state(self):
         """Unknown state returns dash"""
@@ -568,13 +572,17 @@ class TestGetPresenceColor:
         """State 1 (locked) is red"""
         assert get_presence_color(1) == "red"
 
-    def test_inactive_is_yellow(self):
-        """State 2 (inactive) is yellow"""
-        assert get_presence_color(2) == "yellow"
+    def test_idle_is_orange(self):
+        """State 2 (idle) is orange1"""
+        assert get_presence_color(2) == "orange1"
 
-    def test_active_is_green(self):
-        """State 3 (active) is green"""
-        assert get_presence_color(3) == "green"
+    def test_active_is_yellow(self):
+        """State 3 (active) is yellow"""
+        assert get_presence_color(3) == "yellow"
+
+    def test_tui_active_is_green(self):
+        """State 4 (TUI active) is green"""
+        assert get_presence_color(4) == "green"
 
     def test_unknown_is_dim(self):
         """Unknown state is dim"""
@@ -954,8 +962,8 @@ class TestStatusTimelineRender:
         result = widget.render()
         plain = result.plain
         assert "active" in plain
-        assert "inactive" in plain
-        assert "running" in plain
+        assert "idle" in plain
+        assert "running" in plain or "TUI" in plain
 
 
 @pytest.mark.skip(reason="Requires Textual app context")

--- a/tests/unit/test_tui_render.py
+++ b/tests/unit/test_tui_render.py
@@ -259,26 +259,26 @@ class TestRenderPresenceIndicator:
         plain = result.plain
         assert "🔒" in plain
 
-    def test_renders_inactive_state(self):
-        """Should show sleeping icon for state 2."""
+    def test_renders_idle_state(self):
+        """Should show meditating icon for state 2."""
         result = render_presence_indicator(
             presence_state=2,
             idle_seconds=120,
         )
 
         plain = result.plain
-        assert "💤" in plain
+        assert "🧘" in plain
         assert "120s" in plain
 
     def test_renders_active_state(self):
-        """Should show active icon for state 3."""
+        """Should show walking icon for state 3."""
         result = render_presence_indicator(
             presence_state=3,
             idle_seconds=5,
         )
 
         plain = result.plain
-        assert "👤" in plain
+        assert "🚶" in plain
         assert "5s" in plain
 
 

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -332,7 +332,7 @@ class TestBuildPresenceInfo:
         from overcode.web_api import _build_presence_info
         from overcode.monitor_daemon_state import MonitorDaemonState
 
-        for state_code, expected_name in [(1, "locked"), (2, "inactive"), (3, "active")]:
+        for state_code, expected_name in [(0, "asleep"), (1, "locked"), (2, "idle"), (3, "active"), (4, "tui_active")]:
             state = MonitorDaemonState(
                 presence_available=True,
                 presence_state=state_code,


### PR DESCRIPTION
## Summary
Closes #91

- Expands presence tracking from 3 states to 5: asleep (0, ⏻ black), locked (1, 🔒 red), idle (2, 🧘 orange), computer active (3, 🚶 yellow), TUI active (4, 🏃 green)
- TUI writes a throttled heartbeat file on keypress; monitor daemon reads it to distinguish TUI engagement from general computer activity
- Monitor daemon detects sleep via publish-time gap (>2x interval), separating it from screen-locked
- Backwards-compatible with historical CSV data: old values 1-3 read correctly with updated names

## Changes
- **Core**: `classify_state()` now accepts `tui_active` and separates `slept` from `locked` (presence_logger.py, status_constants.py)
- **TUI heartbeat**: `write_tui_heartbeat()` in settings.py, called from `on_key()` in tui.py (throttled to 5s)
- **Monitor daemon**: `PresenceComponent` reads heartbeat file, detects sleep gaps (monitor_daemon.py)
- **Display**: Updated status bar, timeline legend, web API, data export for 5 states
- **Tests**: Updated and expanded — 2939 pass, 1 pre-existing flaky failure (#286)

## Test plan
- [x] `uv run pytest tests/unit/ -v` — 2939 pass (1 pre-existing flaky)
- [ ] Manual: launch TUI, verify status bar shows green 🏃 icon
- [ ] Manual: stop pressing keys for >60s, verify transition to yellow 🚶
- [ ] Manual: lock screen, verify red 🔒 appears
- [ ] Manual: verify timeline shows correct colors for historical data

🤖 Generated with [Claude Code](https://claude.com/claude-code)