### PR TITLE
Add busy_sleeping status detection and sleep countdown column (#289)

### DIFF
--- a/src/overcode/hook_handler.py
+++ b/src/overcode/hook_handler.py
@@ -48,6 +48,7 @@ def write_hook_state(
     tmux_session: str,
     session_name: str,
     tool_name: str | None = None,
+    tool_input: dict | None = None,
 ) -> None:
     """Write hook state JSON for status detection.
 
@@ -62,6 +63,8 @@ def write_hook_state(
     }
     if tool_name is not None:
         state["tool_name"] = tool_name
+    if tool_input is not None:
+        state["tool_input"] = tool_input
 
     state_path.write_text(json.dumps(state))
 
@@ -95,9 +98,10 @@ def handle_hook_event() -> None:
         return
 
     tool_name = data.get("tool_name")
+    tool_input = data.get("tool_input")
 
     # Write state file for status detection
-    write_hook_state(event, tmux_session, session_name, tool_name=tool_name)
+    write_hook_state(event, tmux_session, session_name, tool_name=tool_name, tool_input=tool_input)
 
     # For UserPromptSubmit, check budget and output time-context
     if event == "UserPromptSubmit":

--- a/src/overcode/status_constants.py
+++ b/src/overcode/status_constants.py
@@ -30,6 +30,7 @@ STATUS_ERROR = "error"  # API timeout, etc. (#22)
 STATUS_HEARTBEAT_START = "heartbeat_start"  # First observation of heartbeat-triggered run (timeline only)
 STATUS_DONE = "done"  # Child agent completed its delegated work (#244)
 STATUS_WAITING_OVERSIGHT = "waiting_oversight"  # Child stopped, awaiting oversight report
+STATUS_BUSY_SLEEPING = "busy_sleeping"  # Agent running but executing a sleep command (#289)
 
 # All valid agent status values
 ALL_STATUSES = [
@@ -44,6 +45,7 @@ ALL_STATUSES = [
     STATUS_HEARTBEAT_START,
     STATUS_DONE,
     STATUS_WAITING_OVERSIGHT,
+    STATUS_BUSY_SLEEPING,
 ]
 
 
@@ -87,6 +89,7 @@ STATUS_EMOJIS = {
     STATUS_HEARTBEAT_START: "💚",  # Heartbeat commencement marker (timeline only)
     STATUS_DONE: "☑️",  # Child agent completed delegated work (#244)
     STATUS_WAITING_OVERSIGHT: "👁️",  # Waiting for oversight report
+    STATUS_BUSY_SLEEPING: "🟡",  # Running but sleeping (#289)
 }
 
 
@@ -111,6 +114,7 @@ STATUS_COLORS = {
     STATUS_HEARTBEAT_START: "green",  # Heartbeat commencement (timeline only)
     STATUS_DONE: "dim",  # Done child agent (#244)
     STATUS_WAITING_OVERSIGHT: "yellow",  # Waiting for oversight report
+    STATUS_BUSY_SLEEPING: "yellow",  # Running but sleeping (#289)
 }
 
 
@@ -135,6 +139,7 @@ STATUS_SYMBOLS = {
     STATUS_HEARTBEAT_START: ("💚", "green"),  # Heartbeat commencement (timeline only)
     STATUS_DONE: ("☑️", "dim"),  # Done child agent (#244)
     STATUS_WAITING_OVERSIGHT: ("👁️", "yellow"),  # Waiting for oversight report
+    STATUS_BUSY_SLEEPING: ("🟡", "yellow"),  # Running but sleeping (#289)
 }
 
 
@@ -159,6 +164,7 @@ AGENT_TIMELINE_CHARS = {
     STATUS_HEARTBEAT_START: "💚",  # Green heart emoji - rendered specially by timeline widget
     STATUS_DONE: "✓",  # Done child agent (#244)
     STATUS_WAITING_OVERSIGHT: "▒",  # Waiting for oversight report
+    STATUS_BUSY_SLEEPING: "█",  # Solid - doesn't need human input (#289)
 }
 
 
@@ -242,6 +248,11 @@ def is_user_blocked(status: str) -> bool:
 def is_asleep(status: str) -> bool:
     """Check if status indicates agent is asleep (paused by human)."""
     return status == STATUS_ASLEEP
+
+
+def is_busy_sleeping(status: str) -> bool:
+    """Check if status indicates agent is sleeping via a bash sleep command (#289)."""
+    return status == STATUS_BUSY_SLEEPING
 
 
 def is_done(status: str) -> bool:

--- a/src/overcode/status_patterns.py
+++ b/src/overcode/status_patterns.py
@@ -440,3 +440,37 @@ def clean_line(line: str, patterns: StatusPatterns = None, max_length: int = 80)
         cleaned = cleaned[:max_length - 3] + "..."
 
     return cleaned
+
+
+# Regex for detecting sleep commands in pane content (#289)
+_SLEEP_PATTERN = re.compile(r'\bsleep\s+\d+', re.IGNORECASE)
+_SLEEP_DURATION_PATTERN = re.compile(r'\bsleep\s+(\d+)', re.IGNORECASE)
+
+
+def extract_sleep_duration(text: str) -> int | None:
+    """Extract sleep duration in seconds from a command string.
+
+    Returns None if no sleep duration is parseable.
+
+    Examples:
+        extract_sleep_duration("sleep 30") → 30
+        extract_sleep_duration("sleep 900 && echo check") → 900
+        extract_sleep_duration('Bash("sleep 60")') → 60
+        extract_sleep_duration("Reading config.json") → None
+    """
+    m = _SLEEP_DURATION_PATTERN.search(text)
+    return int(m.group(1)) if m else None
+
+
+def is_sleep_command(text: str) -> bool:
+    """Check if text contains a bash sleep command.
+
+    Matches patterns like: sleep 30, sleep 300, sleep 5m, Bash("sleep 60"), etc.
+
+    Args:
+        text: Line of pane content to check
+
+    Returns:
+        True if the text contains a sleep command
+    """
+    return bool(_SLEEP_PATTERN.search(text))

--- a/src/overcode/summary_columns.py
+++ b/src/overcode/summary_columns.py
@@ -100,6 +100,9 @@ class ColumnContext:
     any_has_oversight_timeout: bool = False
     oversight_deadline: Optional[str] = None
 
+    # Sleep countdown (#289)
+    sleep_wake_estimate: Optional[datetime] = None  # Estimated wake time
+
     # Sister integration (#245)
     source_host: str = ""
     is_remote: bool = False
@@ -162,6 +165,19 @@ def render_time_in_state(ctx: ColumnContext) -> ColumnOutput:
         return [(f"{format_duration(elapsed):>5} ", ctx.status_color)]
     else:
         return [("    - ", ctx.mono(f"dim{ctx.bg}", "dim"))]
+
+
+def render_sleep_countdown(ctx: ColumnContext) -> ColumnOutput:
+    """Countdown to estimated sleep wake time (#289).
+
+    Returns None (hidden, zero width) when the agent is not sleeping.
+    """
+    if ctx.sleep_wake_estimate is None:
+        return None
+    remaining = (ctx.sleep_wake_estimate - datetime.now()).total_seconds()
+    if remaining <= 0:
+        return [("  ⏰ 0s ", ctx.mono(f"bold yellow{ctx.bg}", "bold"))]
+    return [(f" ⏰{format_duration(remaining):>5} ", ctx.mono(f"yellow{ctx.bg}", "bold"))]
 
 
 def render_expand_icon(ctx: ColumnContext) -> ColumnOutput:
@@ -639,6 +655,7 @@ SUMMARY_COLUMNS: List[SummaryColumn] = [
                   label="Status", render_plain=render_status_plain),
     SummaryColumn(id="unvisited_alert", group="identity", detail_levels=ALL, render=render_unvisited_alert),
     SummaryColumn(id="time_in_state", group="identity", detail_levels=ALL, render=render_time_in_state),
+    SummaryColumn(id="sleep_countdown", group="identity", detail_levels=ALL, render=render_sleep_countdown),
     SummaryColumn(id="expand_icon", group="identity", detail_levels=ALL, render=render_expand_icon),
     SummaryColumn(id="agent_name", group="identity", detail_levels=ALL, render=render_agent_name),
     SummaryColumn(id="host", group="sisters", detail_levels=ALL, render=render_host,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -347,6 +347,21 @@ PANE_CONTENT_NARRATIVE_ERROR_PATTERNS = """
 """
 
 
+# Busy sleeping: agent executing a bash sleep command (#289)
+PANE_CONTENT_BASH_SLEEP = """
+⏺ Let me wait before checking again.
+
+  Running Bash("sleep 60")
+"""
+
+PANE_CONTENT_BASH_SLEEP_VARIANT = """
+⏺ Bash  sleep 300
+"""
+
+PANE_CONTENT_BASH_SLEEP_COMPOUND = """
+⏺ Running Bash("sleep 900 && echo 'checking status'")
+"""
+
 # Spawn failure: claude command not found (bash style)
 # Plan mode: idle session — captured from real `claude --permission-mode plan`
 # "plan mode" appears in the ⏸ status bar line, not the banner

--- a/tests/unit/test_hook_handler.py
+++ b/tests/unit/test_hook_handler.py
@@ -65,6 +65,23 @@ class TestWriteHookState:
         assert data["event"] == "PostToolUse"
         assert data["tool_name"] == "Bash"
 
+    def test_writes_tool_input(self, monkeypatch, tmp_path):
+        """tool_input dict should be persisted in hook state (#289)."""
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(tmp_path))
+        write_hook_state("PostToolUse", "agents", "my-agent",
+                         tool_name="Bash", tool_input={"command": "sleep 60"})
+        path = tmp_path / "agents" / "hook_state_my-agent.json"
+        data = json.loads(path.read_text())
+        assert data["tool_input"] == {"command": "sleep 60"}
+
+    def test_omits_tool_input_when_none(self, monkeypatch, tmp_path):
+        """tool_input should not appear in state when not provided."""
+        monkeypatch.setenv("OVERCODE_STATE_DIR", str(tmp_path))
+        write_hook_state("PostToolUse", "agents", "my-agent", tool_name="Bash")
+        path = tmp_path / "agents" / "hook_state_my-agent.json"
+        data = json.loads(path.read_text())
+        assert "tool_input" not in data
+
     def test_creates_directory(self, monkeypatch, tmp_path):
         monkeypatch.setenv("OVERCODE_STATE_DIR", str(tmp_path / "deep" / "nested"))
         write_hook_state("Stop", "agents", "my-agent")

--- a/tests/unit/test_status_detector.py
+++ b/tests/unit/test_status_detector.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
 from overcode.status_detector import StatusDetector
 from overcode.interfaces import MockTmux
+from overcode.status_constants import STATUS_BUSY_SLEEPING
 from tests.fixtures import (
     create_mock_session,
     create_mock_tmux_with_content,
@@ -40,6 +41,9 @@ from tests.fixtures import (
     PANE_CONTENT_NARRATIVE_ERROR_PATTERNS,
     PANE_CONTENT_PLAN_MODE_IDLE,
     PANE_CONTENT_PLAN_APPROVAL,
+    PANE_CONTENT_BASH_SLEEP,
+    PANE_CONTENT_BASH_SLEEP_VARIANT,
+    PANE_CONTENT_BASH_SLEEP_COMPOUND,
 )
 
 
@@ -592,6 +596,97 @@ class TestStatusDetectorSpawnFailure:
         assert "permission denied" in activity.lower(), (
             f"Activity should include 'permission denied', got: {activity}"
         )
+
+
+class TestBusySleepingDetection:
+    """Tests for STATUS_BUSY_SLEEPING detection (#289).
+
+    When an agent executes a Bash sleep command (e.g., as part of a heartbeat
+    polling loop), the status should be busy_sleeping (yellow) not running (green).
+    """
+
+    def test_detects_bash_sleep_as_busy_sleeping(self):
+        """Running Bash('sleep 60') should be detected as busy_sleeping."""
+        mock_tmux = create_mock_tmux_with_content("agents", 1, PANE_CONTENT_BASH_SLEEP)
+        detector = StatusDetector("agents", tmux=mock_tmux)
+        session = create_mock_session(tmux_window=1, standing_instructions="Keep working")
+
+        # Prime content hash
+        detector.detect_status(session)
+        status, activity, _ = detector.detect_status(session)
+
+        assert status == STATUS_BUSY_SLEEPING, (
+            f"Bash sleep should be busy_sleeping, got {status}: {activity}"
+        )
+
+    def test_activity_string_includes_duration(self):
+        """Activity string should include parsed duration like 'Sleeping 1.0m'."""
+        mock_tmux = create_mock_tmux_with_content("agents", 1, PANE_CONTENT_BASH_SLEEP)
+        detector = StatusDetector("agents", tmux=mock_tmux)
+        session = create_mock_session(tmux_window=1, standing_instructions="Keep working")
+
+        # Prime content hash
+        detector.detect_status(session)
+        status, activity, _ = detector.detect_status(session)
+
+        assert "Sleeping" in activity, f"Activity should start with 'Sleeping', got: {activity}"
+        assert "60s" in activity or "1.0m" in activity, (
+            f"Activity should include '60s' or '1.0m', got: {activity}"
+        )
+
+    def test_detects_bash_sleep_variant(self):
+        """'Bash  sleep 300' format should also be detected."""
+        mock_tmux = create_mock_tmux_with_content("agents", 1, PANE_CONTENT_BASH_SLEEP_VARIANT)
+        detector = StatusDetector("agents", tmux=mock_tmux)
+        session = create_mock_session(tmux_window=1, standing_instructions="Keep working")
+
+        # Prime content hash
+        detector.detect_status(session)
+        status, activity, _ = detector.detect_status(session)
+
+        assert status == STATUS_BUSY_SLEEPING, (
+            f"Bash sleep variant should be busy_sleeping, got {status}: {activity}"
+        )
+
+    def test_detects_compound_sleep_command(self):
+        """'sleep 900 && echo ...' should be detected as busy_sleeping."""
+        mock_tmux = create_mock_tmux_with_content("agents", 1, PANE_CONTENT_BASH_SLEEP_COMPOUND)
+        detector = StatusDetector("agents", tmux=mock_tmux)
+        session = create_mock_session(tmux_window=1, standing_instructions="Keep working")
+
+        # Prime content hash
+        detector.detect_status(session)
+        status, activity, _ = detector.detect_status(session)
+
+        assert status == STATUS_BUSY_SLEEPING, (
+            f"Compound sleep command should be busy_sleeping, got {status}: {activity}"
+        )
+
+    def test_regular_bash_still_running(self):
+        """Non-sleep Bash commands should remain STATUS_RUNNING."""
+        content = """
+⏺ Let me run the tests.
+
+  Running Bash("pytest tests/ -v")
+"""
+        mock_tmux = create_mock_tmux_with_content("agents", 1, content)
+        detector = StatusDetector("agents", tmux=mock_tmux)
+        session = create_mock_session(tmux_window=1, standing_instructions="Keep working")
+
+        # Prime content hash
+        detector.detect_status(session)
+        status, activity, _ = detector.detect_status(session)
+
+        assert status == StatusDetector.STATUS_RUNNING, (
+            f"Regular bash should be running, got {status}: {activity}"
+        )
+
+    def test_busy_sleeping_not_green(self):
+        """busy_sleeping should NOT be considered green status."""
+        from overcode.status_constants import is_green_status, is_busy_sleeping
+        assert not is_green_status(STATUS_BUSY_SLEEPING)
+        assert is_busy_sleeping(STATUS_BUSY_SLEEPING)
+        assert not is_busy_sleeping("running")
 
 
 class TestErrorDetection:

--- a/tests/unit/test_summary_columns.py
+++ b/tests/unit/test_summary_columns.py
@@ -14,6 +14,7 @@ from overcode.summary_columns import (
     render_status_symbol,
     render_unvisited_alert,
     render_time_in_state,
+    render_sleep_countdown,
     render_expand_icon,
     render_agent_name,
     render_repo_name,
@@ -298,6 +299,42 @@ class TestRenderTimeInState:
         text = result[0][0].strip()
         # Should show ~30s, not 1h
         assert text != "-"
+
+
+class TestRenderSleepCountdown:
+    """Tests for render_sleep_countdown column (#289)."""
+
+    def test_returns_none_when_not_sleeping(self):
+        """Should return None (zero width) when no sleep_wake_estimate."""
+        ctx = _make_ctx(sleep_wake_estimate=None)
+        assert render_sleep_countdown(ctx) is None
+
+    def test_shows_remaining_time(self):
+        """Should show countdown when sleep_wake_estimate is in the future."""
+        wake_time = datetime.now() + timedelta(seconds=270)  # ~4.5 minutes
+        ctx = _make_ctx(sleep_wake_estimate=wake_time)
+        result = render_sleep_countdown(ctx)
+        assert result is not None
+        text = result[0][0]
+        assert "⏰" in text
+        assert "4.5m" in text or "4.4m" in text  # Allow small timing variance
+
+    def test_shows_zero_when_expired(self):
+        """Should show '0s' when sleep_wake_estimate is in the past."""
+        wake_time = datetime.now() - timedelta(seconds=10)
+        ctx = _make_ctx(sleep_wake_estimate=wake_time)
+        result = render_sleep_countdown(ctx)
+        assert result is not None
+        text = result[0][0]
+        assert "⏰" in text
+        assert "0s" in text
+
+    def test_style_is_yellow(self):
+        """Should use yellow style."""
+        wake_time = datetime.now() + timedelta(seconds=120)
+        ctx = _make_ctx(sleep_wake_estimate=wake_time, monochrome=False)
+        result = render_sleep_countdown(ctx)
+        assert "yellow" in result[0][1]
 
 
 class TestRenderExpandIcon:


### PR DESCRIPTION
## Summary

- Detect when agents execute bash sleep commands (e.g., heartbeat polling loops) and show them as 🟡 `busy_sleeping` instead of 🟢 `running`
- Parse sleep duration from command text and show enriched activity strings like "Sleeping 5.0m"
- Add a new ⏰ countdown column next to time-in-state that ticks down to estimated wake time — hidden (zero width) for non-sleeping agents

## Changes

| File | Change |
|------|--------|
| `status_constants.py` | Add `STATUS_BUSY_SLEEPING` with yellow emoji/color/timeline mappings |
| `status_patterns.py` | Add `extract_sleep_duration()` to parse seconds from `sleep N` commands |
| `status_detector.py` | Enrich activity to "Sleeping Xm" in both sleep detection paths |
| `hook_status_detector.py` | Enrich activity from pane content or `tool_input`; add `_extract_sleep_duration_from_context()` |
| `hook_handler.py` | Forward `tool_input` through hook state for sleep detection |
| `summary_columns.py` | Add `sleep_wake_estimate` field to `ColumnContext`; add `render_sleep_countdown` column |
| `session_summary.py` | Compute `sleep_wake_estimate` from `status_changed_at + duration` |

## Test plan

- [x] `python -m pytest tests/unit/ -v --timeout=30` — all 2982 tests pass
- [ ] Visual: agent running `sleep 300` shows 🟡 with ⏰ countdown ticking down
- [ ] Non-sleeping agents show no extra column width (renderer returns None)

🤖 Generated with [Claude Code](https://claude.com/claude-code)