### PR TITLE
Fix lint issues found by one-time ruff audit

### DIFF
--- a/src/overcode/cli/_shared.py
+++ b/src/overcode/cli/_shared.py
@@ -2,12 +2,9 @@
 Shared CLI state: Typer apps, console, options, and utilities.
 """
 
-import sys
-from pathlib import Path
-from typing import Annotated, Optional, List
+from typing import Annotated
 
 import typer
-from rich import print as rprint
 from rich.console import Console
 
 # Main app

--- a/src/overcode/cli/agent.py
+++ b/src/overcode/cli/agent.py
@@ -167,7 +167,7 @@ def list_agents(
     """
     from ..history_reader import get_session_stats
     from ..tui_helpers import (
-        get_current_state_times, get_status_symbol, get_git_diff_stats,
+        get_status_symbol, get_git_diff_stats,
     )
     from ..monitor_daemon_state import get_monitor_daemon_state
     from ..summary_columns import build_cli_context, SUMMARY_COLUMNS
@@ -426,7 +426,6 @@ def report(
     import os
     import json
     from datetime import datetime
-    from pathlib import Path
 
     if status not in ("success", "failure"):
         rprint(f"[red]Error: --status must be 'success' or 'failure', got '{status}'[/red]")
@@ -777,4 +776,4 @@ def show(
                 print(output)
                 print(f"=== end {name} ===")
             else:
-                rprint(f"[dim]No pane output available[/dim]")
+                rprint("[dim]No pane output available[/dim]")

--- a/src/overcode/cli/budget.py
+++ b/src/overcode/cli/budget.py
@@ -106,7 +106,6 @@ def budget_show(
         overcode budget show my-agent     # Specific agent
     """
     from ..session_manager import SessionManager
-    from ..tui_helpers import format_duration
 
     manager = SessionManager()
 

--- a/src/overcode/cli/daemon.py
+++ b/src/overcode/cli/daemon.py
@@ -76,9 +76,6 @@ def _monitor_daemon_status(session: str):
     """Internal function for showing monitor daemon status."""
     from ..monitor_daemon import is_monitor_daemon_running, get_monitor_daemon_pid
     from ..monitor_daemon_state import get_monitor_daemon_state
-    from ..settings import get_monitor_daemon_state_path
-
-    state_path = get_monitor_daemon_state_path(session)
 
     if not is_monitor_daemon_running(session):
         rprint(f"[dim]Monitor Daemon ({session}):[/dim] ○ stopped")

--- a/src/overcode/cli/hooks.py
+++ b/src/overcode/cli/hooks.py
@@ -33,7 +33,7 @@ def hooks_install(
         level = "user"
 
     try:
-        settings = editor.load()
+        editor.load()
     except ValueError as e:
         rprint(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
@@ -52,7 +52,7 @@ def hooks_install(
         rprint(f"[green]\u2713[/green] Installed {installed} hook(s) in {level} settings")
         rprint(f"  [dim]{editor.path}[/dim]")
         rprint(f"\n  Events: {events}")
-        rprint(f"  All hooks run 'overcode hook-handler' (reads event from stdin).")
+        rprint("  All hooks run 'overcode hook-handler' (reads event from stdin).")
     elif already == len(OVERCODE_HOOKS):
         rprint(f"[green]\u2713[/green] All {already} hooks already installed in {level} settings")
 
@@ -106,12 +106,12 @@ def hooks_status():
             editor.load()
         except ValueError:
             rprint(f"\n{level_name} ({editor.path}):")
-            rprint(f"  [red](invalid JSON)[/red]")
+            rprint("  [red](invalid JSON)[/red]")
             continue
 
         if not editor.path.exists():
             rprint(f"\n{level_name} ({editor.path}):")
-            rprint(f"  [dim](no settings file)[/dim]")
+            rprint("  [dim](no settings file)[/dim]")
             continue
 
         rprint(f"\n{level_name} ({editor.path}):")

--- a/src/overcode/cli/monitoring.py
+++ b/src/overcode/cli/monitoring.py
@@ -9,7 +9,7 @@ from typing import Annotated, Optional, List
 import typer
 from rich import print as rprint
 
-from ._shared import app, SessionOption, _parse_duration
+from ._shared import app, SessionOption
 
 
 @app.command("hook-handler", hidden=True)
@@ -99,7 +99,7 @@ def instruct(
             rprint(f'  "{sess.standing_instructions}"')
         else:
             rprint(f"[dim]No standing instructions set for '{name}'[/dim]")
-            rprint(f"[dim]Tip: Use 'overcode presets' to see available presets[/dim]")
+            rprint("[dim]Tip: Use 'overcode presets' to see available presets[/dim]")
 
 
 def _signal_heartbeat_change(session: str) -> None:
@@ -274,7 +274,7 @@ def monitor(
     """Launch the standalone TUI monitor."""
     if restart:
         from ..monitor_daemon import stop_monitor_daemon, is_monitor_daemon_running, get_monitor_daemon_pid
-        from ..web_server import is_web_server_running, stop_web_server, start_web_server, get_web_server_url
+        from ..web_server import is_web_server_running, stop_web_server, start_web_server
 
         if is_monitor_daemon_running(session):
             pid = get_monitor_daemon_pid(session)
@@ -287,7 +287,7 @@ def monitor(
         if is_web_server_running(session):
             ok, msg = stop_web_server(session)
             if ok:
-                rprint(f"[green]✓[/green] Web server stopped")
+                rprint("[green]✓[/green] Web server stopped")
                 started, start_msg = start_web_server(session)
                 if started:
                     rprint(f"[green]✓[/green] Web server restarted ({start_msg})")
@@ -363,7 +363,7 @@ def web(
     if stop:
         success, msg = stop_web_server(session)
         if success:
-            print(f"Web server stopped.")
+            print("Web server stopped.")
         else:
             print(f"Web server: {msg}")
         return
@@ -466,7 +466,7 @@ def history(
             rprint(f"  Ended: {end_time}")
         rprint(f"  Directory: {session.start_directory or '-'}")
         rprint(f"  Repo: {session.repo_name or '-'} ({session.branch or '-'})")
-        rprint(f"\n  [bold]Stats:[/bold]")
+        rprint("\n  [bold]Stats:[/bold]")
         stats = session.stats
         rprint(f"    Interactions: {stats.interaction_count}")
         rprint(f"    Tokens: {format_tokens(stats.total_tokens)}")
@@ -550,12 +550,12 @@ def usage():
     five_h_style = _pct_style(snap.five_hour_pct)
     seven_d_style = _pct_style(snap.seven_day_pct)
 
-    rprint(f"\n[bold]Claude Code Usage[/bold]\n")
+    rprint("\n[bold]Claude Code Usage[/bold]\n")
     rprint(f"  5h session:  [{five_h_style}]{snap.five_hour_pct:.0f}%[/{five_h_style}]{_fmt_reset(snap.five_hour_resets_at)}")
     rprint(f"  7d weekly:   [{seven_d_style}]{snap.seven_day_pct:.0f}%[/{seven_d_style}]{_fmt_reset(snap.seven_day_resets_at)}")
 
     if snap.opus_pct is not None or snap.sonnet_pct is not None:
-        rprint(f"\n  [bold]Model breakdown (7d):[/bold]")
+        rprint("\n  [bold]Model breakdown (7d):[/bold]")
         if snap.opus_pct is not None:
             opus_style = _pct_style(snap.opus_pct)
             rprint(f"    Opus:      [{opus_style}]{snap.opus_pct:.0f}%[/{opus_style}]")

--- a/src/overcode/cli/perms.py
+++ b/src/overcode/cli/perms.py
@@ -129,12 +129,12 @@ def perms_status():
             editor.load()
         except ValueError:
             rprint(f"\n{level_name} ({editor.path}):")
-            rprint(f"  [red](invalid JSON)[/red]")
+            rprint("  [red](invalid JSON)[/red]")
             continue
 
         if not editor.path.exists():
             rprint(f"\n{level_name} ({editor.path}):")
-            rprint(f"  [dim](no settings file)[/dim]")
+            rprint("  [dim](no settings file)[/dim]")
             continue
 
         rprint(f"\n{level_name} ({editor.path}):")

--- a/src/overcode/cli/sister.py
+++ b/src/overcode/cli/sister.py
@@ -134,30 +134,30 @@ def sister_allow_control(
         api_key = get_web_api_key()
         web["allow_control"] = True
         save_config(config)
-        rprint(f"[green]✓ Remote control enabled (web.allow_control = true)[/green]")
+        rprint("[green]✓ Remote control enabled (web.allow_control = true)[/green]")
         if api_key:
             masked_key = api_key[:4] + "..."
             rprint(f"  API key: {masked_key}")
         else:
-            rprint(f"  [yellow]Warning: web.api_key is not set — endpoints are unauthenticated[/yellow]")
-            rprint(f"  [dim]This is fine if you're using SSH tunnels. Otherwise set it in ~/.overcode/config.yaml:[/dim]")
+            rprint("  [yellow]Warning: web.api_key is not set — endpoints are unauthenticated[/yellow]")
+            rprint("  [dim]This is fine if you're using SSH tunnels. Otherwise set it in ~/.overcode/config.yaml:[/dim]")
             rprint()
             rprint("  web:")
             rprint('    api_key: "your-secret-key"')
-        rprint(f"  Restart web server for changes to take effect.")
+        rprint("  Restart web server for changes to take effect.")
     elif off:
         web["allow_control"] = False
         save_config(config)
-        rprint(f"[green]✓ Remote control disabled (web.allow_control = false)[/green]")
+        rprint("[green]✓ Remote control disabled (web.allow_control = false)[/green]")
     else:
         # Show current status
         enabled = web.get("allow_control", False)
         api_key = get_web_api_key()
         if enabled:
             masked_key = (api_key[:4] + "...") if api_key else "(not set)"
-            rprint(f"Remote control: [green]enabled[/green]")
+            rprint("Remote control: [green]enabled[/green]")
             rprint(f"  API key: {masked_key}")
         else:
-            rprint(f"Remote control: [red]disabled[/red]")
+            rprint("Remote control: [red]disabled[/red]")
             if not api_key:
-                rprint(f"  [dim]Note: web.api_key is also not set[/dim]")
+                rprint("  [dim]Note: web.api_key is also not set[/dim]")

--- a/src/overcode/daemon_logging.py
+++ b/src/overcode/daemon_logging.py
@@ -7,7 +7,7 @@ monitor_daemon and supervisor_daemon.
 
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 from rich.console import Console
 from rich.text import Text

--- a/src/overcode/data_export.py
+++ b/src/overcode/data_export.py
@@ -6,7 +6,7 @@ Exports session data to Parquet format for analysis in Jupyter notebooks.
 
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 
 from .session_manager import SessionManager
 from .status_history import read_agent_status_history

--- a/src/overcode/follow_mode.py
+++ b/src/overcode/follow_mode.py
@@ -13,7 +13,6 @@ import sys
 import time
 from collections import deque
 from datetime import datetime
-from pathlib import Path
 from typing import Optional
 
 from .session_manager import SessionManager

--- a/src/overcode/history_reader.py
+++ b/src/overcode/history_reader.py
@@ -17,7 +17,6 @@ Each assistant message in session files has usage data:
 """
 
 import json
-import os
 import threading
 import time
 from pathlib import Path

--- a/src/overcode/implementations.py
+++ b/src/overcode/implementations.py
@@ -7,6 +7,7 @@ and perform real file I/O.
 
 import json
 import os
+import subprocess
 import time
 from pathlib import Path
 from typing import Optional, List, Dict, Any

--- a/src/overcode/launcher.py
+++ b/src/overcode/launcher.py
@@ -12,7 +12,6 @@ import subprocess
 import os
 import shlex
 from typing import List, Optional
-from pathlib import Path
 
 import re
 

--- a/src/overcode/logging_config.py
+++ b/src/overcode/logging_config.py
@@ -10,7 +10,6 @@ Provides centralized logging configuration with support for:
 
 import logging
 import sys
-from datetime import datetime
 from pathlib import Path
 from typing import Optional
 

--- a/src/overcode/monitor_daemon.py
+++ b/src/overcode/monitor_daemon.py
@@ -34,7 +34,6 @@ from .history_reader import get_session_stats, get_current_session_id_for_direct
 from .monitor_daemon_state import (
     MonitorDaemonState,
     SessionDaemonState,
-    get_monitor_daemon_state,
 )
 from .pid_utils import (
     acquire_daemon_lock,
@@ -44,7 +43,6 @@ from .session_manager import SessionManager
 from .settings import (
     DAEMON,
     DAEMON_VERSION,
-    PATHS,
     ensure_session_dir,
     get_monitor_daemon_pid_path,
     get_monitor_daemon_state_path,
@@ -62,11 +60,9 @@ from .status_constants import (
     STATUS_RUNNING_HEARTBEAT,
     STATUS_TERMINATED,
     STATUS_WAITING_HEARTBEAT,
-    STATUS_WAITING_OVERSIGHT,
     is_green_status,
 )
-from .status_detector import StatusDetector, PollingStatusDetector
-from .hook_status_detector import HookStatusDetector
+from .status_detector import StatusDetector
 from .status_detector_factory import StatusDetectorDispatcher
 from .status_history import log_agent_status
 from .monitor_daemon_core import (
@@ -756,7 +752,7 @@ class MonitorDaemon:
             import urllib.error
 
             # Build status payload using web_api format
-            from .web_api import get_status_data, get_timeline_data
+            from .web_api import get_status_data
 
             payload = get_status_data(self.tmux_session)
 
@@ -779,7 +775,7 @@ class MonitorDaemon:
                 if resp.status == 200:
                     self.state.relay_last_push = now.isoformat()
                     self.state.relay_last_status = "ok"
-                    self.log.debug(f"Relay push OK")
+                    self.log.debug("Relay push OK")
                 else:
                     self.state.relay_last_status = "error"
                     self.log.warn(f"Relay push failed: HTTP {resp.status}")

--- a/src/overcode/status_detector.py
+++ b/src/overcode/status_detector.py
@@ -18,7 +18,6 @@ from .status_patterns import (
     matches_any,
     find_matching_line,
     is_status_bar_line,
-    is_command_menu_line,
     count_command_menu_lines,
     clean_line,
     strip_ansi,
@@ -131,8 +130,6 @@ class PollingStatusDetector:
 
         if not last_lines:
             return self.STATUS_WAITING_USER, "No output", content
-
-        last_line = last_lines[-1]
 
         # Check for spawn failure FIRST (command not found, etc.)
         # This should be detected before shell prompt check because the error

--- a/src/overcode/status_detector_factory.py
+++ b/src/overcode/status_detector_factory.py
@@ -9,7 +9,6 @@ auto-dispatches per-session based on session.hook_status_detection (#5).
 from typing import Optional, Tuple, TYPE_CHECKING
 
 from .protocols import StatusDetectorProtocol
-from .status_constants import DEFAULT_CAPTURE_LINES
 
 if TYPE_CHECKING:
     from .protocols import TmuxInterface

--- a/src/overcode/summary_columns.py
+++ b/src/overcode/summary_columns.py
@@ -21,7 +21,6 @@ from .tui_helpers import (
     format_duration,
     format_line_count,
     format_tokens,
-    format_budget,
     calculate_uptime,
     get_current_state_times,
     get_status_symbol,
@@ -421,7 +420,7 @@ def render_bash_count(ctx: ColumnContext) -> ColumnOutput:
 def render_child_count(ctx: ColumnContext) -> ColumnOutput:
     count = ctx.child_count
     if count == 0:
-        return [(f" 👶 0", ctx.mono(f"dim{ctx.bg}", "dim"))]
+        return [(" 👶 0", ctx.mono(f"dim{ctx.bg}", "dim"))]
     style = ctx.mono(f"bold cyan{ctx.bg}", "bold")
     return [(f" 👶{count:>2}", style)]
 
@@ -571,7 +570,6 @@ def render_agent_value(ctx: ColumnContext) -> ColumnOutput:
 def render_status_plain(ctx: ColumnContext) -> Optional[str]:
     """Status with time-in-state."""
     # Determine status name from the symbol
-    s = ctx.session
     status = "unknown"
     # Reverse-lookup from status_symbol
     for candidate in ALL_STATUSES:

--- a/src/overcode/summary_groups.py
+++ b/src/overcode/summary_groups.py
@@ -4,7 +4,7 @@ Summary line group definitions for the TUI.
 Defines which fields belong to each group and their default visibility.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List
 
 

--- a/src/overcode/supervisor_daemon.py
+++ b/src/overcode/supervisor_daemon.py
@@ -44,16 +44,13 @@ from .pid_utils import (
 from .session_manager import SessionManager
 from .settings import (
     DAEMON,
-    PATHS,
     ensure_session_dir,
     get_supervisor_daemon_pid_path,
     get_supervisor_log_path,
     get_supervisor_stats_path,
 )
 from .status_constants import (
-    STATUS_RUNNING,
     STATUS_WAITING_USER,
-    get_status_emoji,
 )
 from .status_patterns import get_patterns
 from .tmux_manager import TmuxManager
@@ -63,8 +60,6 @@ from .supervisor_daemon_core import (
     build_daemon_claude_context as _build_daemon_claude_context,
     filter_non_green_sessions,
     calculate_daemon_claude_run_seconds,
-    should_launch_daemon_claude,
-    parse_intervention_log_line,
     check_daemon_output_completion,
     check_daemon_tool_activity,
     determine_supervisor_action,

--- a/src/overcode/supervisor_daemon_core.py
+++ b/src/overcode/supervisor_daemon_core.py
@@ -8,7 +8,7 @@ They are used by SupervisorDaemon but can be tested independently.
 from dataclasses import dataclass
 from typing import List, Optional
 
-from .status_constants import STATUS_RUNNING, get_status_emoji, is_green_status
+from .status_constants import get_status_emoji, is_green_status
 
 
 def build_daemon_claude_context(

--- a/src/overcode/testing/renderer.py
+++ b/src/overcode/testing/renderer.py
@@ -1,7 +1,6 @@
 """Render terminal output with ANSI codes to PNG images."""
 
 from pathlib import Path
-from typing import Optional
 import pyte
 from PIL import Image, ImageDraw, ImageFont
 
@@ -149,7 +148,6 @@ def render_terminal_to_png(
 
     # Find actual content bounds (non-empty rows)
     first_row = 0
-    last_row = internal_height - 1
     for y in range(internal_height):
         row_has_content = any(
             screen.buffer[y][x].data.strip()
@@ -159,7 +157,6 @@ def render_terminal_to_png(
         if row_has_content:
             if first_row == 0:
                 first_row = y
-            last_row = y
 
     # Use the requested height - the large internal buffer prevents scrolling,
     # and we render from first_row for `height` rows

--- a/src/overcode/testing/tui_eye.py
+++ b/src/overcode/testing/tui_eye.py
@@ -13,9 +13,8 @@ Example usage:
     tui-eye stop
 """
 
-import sys
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated
 import typer
 
 from .tmux_driver import TUIDriver

--- a/src/overcode/time_context.py
+++ b/src/overcode/time_context.py
@@ -12,7 +12,7 @@ All functions are pure (no Rich/Typer dependencies) for easy testing.
 
 import json
 import os
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Optional, Tuple
 

--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -9,21 +9,18 @@ TODO: Split this file into smaller modules for maintainability:
 """
 
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import List, Optional
 import subprocess
 import sys
 import time
 
 from textual.app import App, ComposeResult
-from textual.containers import Container, Vertical, ScrollableContainer, Horizontal
-from textual.widgets import Header, Footer, Static, Label, Input, TextArea
+from textual.containers import ScrollableContainer
+from textual.widgets import Header, Static, Input, TextArea
 from textual.reactive import reactive
 from textual.css.query import NoMatches
 from textual import events, work
-from textual.message import Message
-from rich.text import Text
-from rich.panel import Panel
 
 from . import __version__
 from .session_manager import SessionManager, Session
@@ -31,63 +28,27 @@ from .launcher import ClaudeLauncher
 from .status_detector_factory import StatusDetectorDispatcher
 from .status_constants import DEFAULT_CAPTURE_LINES, STATUS_RUNNING, STATUS_RUNNING_HEARTBEAT, STATUS_WAITING_HEARTBEAT, STATUS_WAITING_OVERSIGHT, STATUS_WAITING_USER, is_green_status
 from .history_reader import get_session_stats, ClaudeSessionStats, HistoryFile
-from .settings import signal_activity, write_tui_heartbeat, get_session_dir, get_agent_history_path, get_event_loop_timing_path, TUIPreferences, DAEMON_VERSION  # Activity signaling to daemon
-from .monitor_daemon_state import MonitorDaemonState, get_monitor_daemon_state
+from .settings import signal_activity, write_tui_heartbeat, get_event_loop_timing_path, TUIPreferences  # Activity signaling to daemon
+from .monitor_daemon_state import get_monitor_daemon_state
 from .monitor_daemon import (
     is_monitor_daemon_running,
-    stop_monitor_daemon,
 )
 from .pid_utils import count_daemon_processes
-from .supervisor_daemon import (
-    is_supervisor_daemon_running,
-    stop_supervisor_daemon,
-)
 from .summarizer_component import (
     SummarizerComponent,
     SummarizerConfig,
     AgentSummary,
 )
-from .summarizer_client import SummarizerClient
-from .web_server import (
-    is_web_server_running,
-    get_web_server_url,
-    toggle_web_server,
-)
-from .config import get_default_standing_instructions
 from .sister_poller import SisterPoller
-from .status_history import read_agent_status_history
 from .usage_monitor import UsageMonitor
-from .presence_logger import read_presence_history, MACOS_APIS_AVAILABLE
-from .launcher import ClaudeLauncher
 from .implementations import RealTmux
 from .tui_helpers import (
-    format_interval,
-    format_ago,
     format_duration,
-    format_tokens,
-    format_line_count,
-    calculate_uptime,
-    presence_state_to_char,
-    agent_status_to_char,
-    get_current_state_times,
-    build_timeline_slots,
-    build_timeline_string,
-    get_status_symbol,
-    get_presence_color,
-    get_agent_timeline_color,
-    style_pane_line,
-    truncate_name,
-    get_daemon_status_style,
     get_git_diff_stats,
-    calculate_safe_break_duration,
 )
 from .tui_logic import (
     sort_sessions,
     filter_visible_sessions,
-    get_sort_mode_display_name,
-    cycle_sort_mode,
-    calculate_green_percentage,
-    calculate_human_interaction_count,
     compute_tree_metadata,
     compute_stall_state,
     should_send_stall_notification,

--- a/src/overcode/tui_actions/navigation.py
+++ b/src/overcode/tui_actions/navigation.py
@@ -4,7 +4,7 @@ Navigation action methods for TUI.
 Handles moving between sessions in the list.
 """
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..tui_widgets import SessionSummary

--- a/src/overcode/tui_helpers.py
+++ b/src/overcode/tui_helpers.py
@@ -17,7 +17,6 @@ from .status_constants import (
     get_presence_color as _get_presence_color,
     get_daemon_status_style as _get_daemon_status_style,
     STATUS_ASLEEP,
-    STATUS_RUNNING,
     STATUS_TERMINATED,
     is_green_status,
 )

--- a/src/overcode/tui_render.py
+++ b/src/overcode/tui_render.py
@@ -9,7 +9,7 @@ No side effects, no external dependencies.
 """
 
 from datetime import datetime
-from typing import Optional, List, Dict, Tuple
+from typing import Optional, List, Tuple
 from rich.text import Text
 
 from .status_constants import is_green_status
@@ -22,7 +22,6 @@ from .tui_helpers import (
     get_status_symbol,
     get_daemon_status_style,
     calculate_uptime,
-    get_current_state_times,
 )
 from .settings import DAEMON_VERSION
 

--- a/src/overcode/tui_widgets/daemon_status_bar.py
+++ b/src/overcode/tui_widgets/daemon_status_bar.py
@@ -268,7 +268,7 @@ class DaemonStatusBar(Static):
                 content.append(" │ ", style="dim")
                 content.append("☕", style="bold")
                 if safe_break < 60:
-                    content.append(f" <1m", style="bold red")
+                    content.append(" <1m", style="bold red")
                 elif safe_break < 300:  # < 5 min
                     content.append(f" {format_duration(safe_break)}", style="bold yellow")
                 else:

--- a/src/overcode/tui_widgets/session_summary.py
+++ b/src/overcode/tui_widgets/session_summary.py
@@ -18,7 +18,6 @@ from ..status_constants import get_status_color
 from ..status_patterns import extract_background_bash_count, extract_live_subagent_count, extract_sleep_duration
 from ..history_reader import get_session_stats, ClaudeSessionStats
 from ..tui_helpers import (
-    format_duration,
     calculate_uptime,
     get_current_state_times,
     get_status_symbol,

--- a/src/overcode/tui_widgets/summary_config_modal.py
+++ b/src/overcode/tui_widgets/summary_config_modal.py
@@ -8,7 +8,6 @@ Updates live summary lines as you toggle groups.
 
 from typing import Dict, Optional, Any
 
-from textual.app import ComposeResult
 from textual.widgets import Static
 from textual.message import Message
 from textual import events

--- a/src/overcode/web_api.py
+++ b/src/overcode/web_api.py
@@ -27,7 +27,6 @@ from .status_constants import (
     get_status_color,
     is_green_status,
     AGENT_TIMELINE_CHARS,
-    PRESENCE_TIMELINE_CHARS,
 )
 
 

--- a/src/overcode/web_server.py
+++ b/src/overcode/web_server.py
@@ -7,11 +7,9 @@ Uses Python stdlib http.server - no additional dependencies required.
 """
 
 import json
-import os
 import sys
 from datetime import datetime
 from http.server import HTTPServer, BaseHTTPRequestHandler
-from pathlib import Path
 from typing import Optional, Tuple
 from urllib.parse import urlparse, parse_qs
 
@@ -220,7 +218,6 @@ class OvercodeHandler(BaseHTTPRequestHandler):
 
     def _route_control(self, method: str) -> None:
         """Route POST/PUT/DELETE requests to control API handlers."""
-        from . import web_control_api as api
         from .web_control_api import ControlError
 
         if not self._check_auth():
@@ -436,14 +433,14 @@ def run_server(
     # Get actual bound address for display
     bound_host, bound_port = server.server_address
 
-    print(f"Overcode Web Server")
-    print(f"====================")
+    print("Overcode Web Server")
+    print("====================")
     print(f"Monitoring tmux session: {tmux_session}")
-    print(f"")
+    print("")
     print(f"  Analytics:  http://localhost:{bound_port}/")
     print(f"  Dashboard:  http://localhost:{bound_port}/dashboard")
     print(f"  API Status: http://localhost:{bound_port}/api/status")
-    print(f"")
+    print("")
     print(f"Local:   http://localhost:{bound_port}")
 
     if host == "0.0.0.0":
@@ -458,9 +455,9 @@ def run_server(
         except Exception:
             print(f"Network: http://<your-ip>:{bound_port}")
 
-    print(f"")
-    print(f"Press Ctrl+C to stop")
-    print(f"")
+    print("")
+    print("Press Ctrl+C to stop")
+    print("")
 
     try:
         server.serve_forever()


### PR DESCRIPTION
## Summary
- Add missing `import subprocess` in `implementations.py` — `RealSubprocess` class would crash at runtime (real bug, never hit because class is only used in interface tests)
- Remove ~100 unused imports across 30 `src/` files
- Remove 5 unused variable assignments
- Remove duplicate `ClaudeLauncher` import in `tui.py`
- Fix ~30 f-strings that had no placeholders (removed `f` prefix)

Not adding ruff as a permanent dependency — this was a one-time diagnostic pass.

## Test plan
- [x] Full unit test suite: 3021 passed, 11 skipped
- [x] Verified remaining ruff warnings are all intentional (1 pyarrow availability check, 9 TYPE_CHECKING mixin imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)