### PR TITLE
Add --teams flag to enable agent teams on launch

### DIFF
--- a/src/overcode/cli/agent.py
+++ b/src/overcode/cli/agent.py
@@ -59,6 +59,10 @@ def launch(
         Optional[List[str]],
         typer.Option("--claude-arg", help="Extra Claude CLI flag (repeatable, e.g. '--model haiku')"),
     ] = None,
+    teams: Annotated[
+        bool,
+        typer.Option("--teams", help="Enable Claude Code agent teams (CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS)"),
+    ] = False,
     session: SessionOption = "agents",
 ):
     """Launch a new Claude agent."""
@@ -104,6 +108,7 @@ def launch(
         parent_name=parent,
         allowed_tools=allowed_tools,
         extra_claude_args=claude_args,
+        agent_teams=teams,
     )
 
     if result:
@@ -116,6 +121,8 @@ def launch(
             rprint(f"  Allowed tools: {allowed_tools}")
         if claude_args:
             rprint(f"  Extra Claude args: {' '.join(claude_args)}")
+        if teams:
+            rprint("  Agent teams: enabled")
 
         # Store oversight policy on session
         if oversight_policy != "wait" or oversight_timeout_seconds > 0:

--- a/src/overcode/launcher.py
+++ b/src/overcode/launcher.py
@@ -77,6 +77,7 @@ class ClaudeLauncher:
         parent_name: Optional[str] = None,
         allowed_tools: Optional[str] = None,
         extra_claude_args: Optional[List[str]] = None,
+        agent_teams: bool = False,
     ) -> Optional[Session]:
         """
         Launch an interactive Claude Code session in a tmux window.
@@ -174,6 +175,10 @@ class ClaudeLauncher:
         # Add parent env vars for hierarchy (#244)
         if parent_session:
             env_prefix += f" OVERCODE_PARENT_SESSION_ID={parent_session.id} OVERCODE_PARENT_NAME={parent_session.name}"
+
+        # Enable Claude Code agent teams if requested
+        if agent_teams:
+            env_prefix += " CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1"
 
         # If MOCK_SCENARIO is set, prepend it to the command for testing
         mock_scenario = os.environ.get("MOCK_SCENARIO")


### PR DESCRIPTION
## Summary
- Adds a `--teams` flag to `overcode launch` that sets `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in the launched agent's environment
- Enables Claude Code's experimental agent teams feature on a per-agent basis without requiring global env var configuration
- Includes confirmation output when the flag is used

## Usage
```bash
overcode launch --name my-lead --teams -p "Coordinate a team to refactor auth"
```

## Test plan
- [x] Unit test: `--teams` sets `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in the tmux command
- [x] Unit test: without `--teams`, the env var is absent
- [x] Full launcher test suite passes (53/53)

🤖 Generated with [Claude Code](https://claude.com/claude-code)