### PR TITLE
Fix command bar targeting wrong agent when local/remote share a name

### DIFF
--- a/src/overcode/launcher.py
+++ b/src/overcode/launcher.py
@@ -472,6 +472,33 @@ class ClaudeLauncher:
             print(f"Session '{name}' not found")
             return False
 
+        return self._send_to_resolved_session(session, text, enter)
+
+    def send_to_session_by_id(self, session_id: str, text: str, enter: bool = True) -> bool:
+        """Send text/keys to a session by ID.
+
+        Preferred over send_to_session() when the session ID is known,
+        since IDs are unique even when local and remote agents share a name.
+
+        Args:
+            session_id: Unique session ID
+            text: Text to send (or special key like "Enter", "Escape")
+            enter: Whether to press Enter after the text (default: True)
+
+        Returns:
+            True if successful, False otherwise
+        """
+        session = self.sessions.get_session(session_id)
+        if session is None:
+            return False
+
+        return self._send_to_resolved_session(session, text, enter)
+
+    def _send_to_resolved_session(self, session: Session, text: str, enter: bool = True) -> bool:
+        """Send text/keys to an already-resolved session.
+
+        Internal helper shared by send_to_session() and send_to_session_by_id().
+        """
         # Handle special keys
         special_keys = {
             "enter": "",  # Empty string + Enter = just press Enter

--- a/src/overcode/tui_actions/input.py
+++ b/src/overcode/tui_actions/input.py
@@ -87,7 +87,7 @@ class InputActionsMixin:
         )
 
         # Send "enter" which the launcher handles as just pressing Enter
-        if launcher.send_to_session(session_name, "enter"):
+        if launcher.send_to_session_by_id(session.id, "enter"):
             self.notify(f"Sent Enter to {session_name}", severity="information")
         else:
             self.notify(f"Failed to send Enter to {session_name}", severity="error")
@@ -112,7 +112,7 @@ class InputActionsMixin:
             session_manager=self.session_manager
         )
 
-        if launcher.send_to_session(session_name, "escape"):
+        if launcher.send_to_session_by_id(session.id, "escape"):
             self.notify(f"Sent Escape to {session_name}", severity="information")
         else:
             self.notify(f"Failed to send Escape to {session_name}", severity="error")
@@ -188,7 +188,7 @@ class InputActionsMixin:
         is_freetext = self._is_freetext_option(pane_content, key)
 
         # Send the key followed by Enter (to select the numbered option)
-        if launcher.send_to_session(session_name, key, enter=True):
+        if launcher.send_to_session_by_id(session.id, key, enter=True):
             self.notify(f"Sent '{key}' to {session_name}", severity="information")
             # Open command bar if this was a free-text instruction option (#72)
             if is_freetext:

--- a/src/overcode/tui_actions/session.py
+++ b/src/overcode/tui_actions/session.py
@@ -496,12 +496,12 @@ class SessionActionsMixin:
             # (Textual's internal focus) which diverges during DOM reordering
             focused = self._get_focused_widget()
             if focused:
-                cmd_bar.set_target(focused.session.name)
+                cmd_bar.set_target(focused.session.name, session_id=focused.session.id)
                 if get_prefill:
                     cmd_input = cmd_bar.query_one("#cmd-input", Input)
                     cmd_input.value = get_prefill(focused.session)
             elif not cmd_bar.target_session and self.sessions:
-                cmd_bar.set_target(self.sessions[0].name)
+                cmd_bar.set_target(self.sessions[0].name, session_id=self.sessions[0].id)
                 if fallback_prefill is not None:
                     cmd_input = cmd_bar.query_one("#cmd-input", Input)
                     cmd_input.value = fallback_prefill
@@ -612,7 +612,7 @@ class SessionActionsMixin:
                 if result.ok:
                     success_count += 1
             else:
-                if launcher.send_to_session(session.name, handover_instruction):
+                if launcher.send_to_session_by_id(session.id, handover_instruction):
                     success_count += 1
 
         if success_count == len(sessions):

--- a/tests/unit/test_tui_actions_input.py
+++ b/tests/unit/test_tui_actions_input.py
@@ -375,11 +375,11 @@ class TestSendEscapeToFocused:
         mock_tui.focused = mock_widget
 
         mock_launcher_instance = MockLauncher.return_value
-        mock_launcher_instance.send_to_session.return_value = True
+        mock_launcher_instance.send_to_session_by_id.return_value = True
 
         InputActionsMixin.action_send_escape_to_focused(mock_tui)
 
-        mock_launcher_instance.send_to_session.assert_called_once_with("local-agent", "escape")
+        mock_launcher_instance.send_to_session_by_id.assert_called_once_with(mock_session.id, "escape")
         mock_tui.notify.assert_called_once()
         assert "Sent Escape" in mock_tui.notify.call_args[0][0]
         assert mock_tui.notify.call_args[1]["severity"] == "information"
@@ -401,7 +401,7 @@ class TestSendEscapeToFocused:
         mock_tui.focused = mock_widget
 
         mock_launcher_instance = MockLauncher.return_value
-        mock_launcher_instance.send_to_session.return_value = False
+        mock_launcher_instance.send_to_session_by_id.return_value = False
 
         InputActionsMixin.action_send_escape_to_focused(mock_tui)
 

--- a/tests/unit/test_tui_actions_session.py
+++ b/tests/unit/test_tui_actions_session.py
@@ -985,7 +985,7 @@ class TestExecuteTransportAll:
         mock_result.ok = True
 
         mock_launcher_instance = MockLauncher.return_value
-        mock_launcher_instance.send_to_session.return_value = True
+        mock_launcher_instance.send_to_session_by_id.return_value = True
 
         mock_tui = MagicMock()
         mock_tui._is_remote = SessionActionsMixin._is_remote.__get__(mock_tui)
@@ -994,8 +994,8 @@ class TestExecuteTransportAll:
         SessionActionsMixin._execute_transport_all(mock_tui, [local_session, remote_session])
 
         # Local agent should be sent via launcher
-        mock_launcher_instance.send_to_session.assert_called_once()
-        assert mock_launcher_instance.send_to_session.call_args[0][0] == "local-agent"
+        mock_launcher_instance.send_to_session_by_id.assert_called_once()
+        assert mock_launcher_instance.send_to_session_by_id.call_args[0][0] == local_session.id
 
         # Remote agent should be sent via sister controller
         mock_tui._sister_controller.send_instruction.assert_called_once()
@@ -1024,7 +1024,7 @@ class TestExecuteTransportAll:
 
         mock_launcher_instance = MockLauncher.return_value
         # First send succeeds, second fails
-        mock_launcher_instance.send_to_session.side_effect = [True, False]
+        mock_launcher_instance.send_to_session_by_id.side_effect = [True, False]
 
         mock_tui = MagicMock()
         mock_tui._is_remote = SessionActionsMixin._is_remote.__get__(mock_tui)
@@ -1050,14 +1050,14 @@ class TestExecuteTransportAll:
         session2.name = "agent-2"
 
         mock_launcher_instance = MockLauncher.return_value
-        mock_launcher_instance.send_to_session.return_value = True
+        mock_launcher_instance.send_to_session_by_id.return_value = True
 
         mock_tui = MagicMock()
         mock_tui._is_remote = SessionActionsMixin._is_remote.__get__(mock_tui)
 
         SessionActionsMixin._execute_transport_all(mock_tui, [session1, session2])
 
-        assert mock_launcher_instance.send_to_session.call_count == 2
+        assert mock_launcher_instance.send_to_session_by_id.call_count == 2
         mock_tui.notify.assert_called_once()
         assert "2 agent(s)" in mock_tui.notify.call_args[0][0]
         assert mock_tui.notify.call_args[1]["severity"] == "information"
@@ -1660,7 +1660,7 @@ class TestFocusCommandBar:
         SessionActionsMixin.action_focus_command_bar(mock_tui)
 
         mock_cmd_bar.add_class.assert_called_once_with("visible")
-        mock_cmd_bar.set_target.assert_called_once_with("test-agent")
+        mock_cmd_bar.set_target.assert_called_once_with("test-agent", session_id=mock_session.id)
         mock_input.focus.assert_called_once()
 
     def test_defaults_to_first_session_when_no_focus(self):
@@ -1680,7 +1680,7 @@ class TestFocusCommandBar:
 
         SessionActionsMixin.action_focus_command_bar(mock_tui)
 
-        mock_cmd_bar.set_target.assert_called_once_with("first-agent")
+        mock_cmd_bar.set_target.assert_called_once_with("first-agent", session_id=mock_session.id)
 
     def test_handles_no_matches(self):
         """Should handle NoMatches gracefully."""
@@ -1721,7 +1721,7 @@ class TestFocusStandingOrders:
 
         SessionActionsMixin.action_focus_standing_orders(mock_tui)
 
-        mock_cmd_bar.set_target.assert_called_once_with("test-agent")
+        mock_cmd_bar.set_target.assert_called_once_with("test-agent", session_id=mock_session.id)
         mock_cmd_bar.set_mode.assert_called_once_with("standing_orders")
         # Should pre-fill with existing standing orders
         assert mock_input.value == "Do the thing"
@@ -1753,7 +1753,7 @@ class TestFocusHumanAnnotation:
 
         SessionActionsMixin.action_focus_human_annotation(mock_tui)
 
-        mock_cmd_bar.set_target.assert_called_once_with("test-agent")
+        mock_cmd_bar.set_target.assert_called_once_with("test-agent", session_id=mock_session.id)
         mock_cmd_bar.set_mode.assert_called_once_with("annotation")
         assert mock_input.value == "Needs review"
 
@@ -1784,7 +1784,7 @@ class TestEditAgentValue:
 
         SessionActionsMixin.action_edit_agent_value(mock_tui)
 
-        mock_cmd_bar.set_target.assert_called_once_with("test-agent")
+        mock_cmd_bar.set_target.assert_called_once_with("test-agent", session_id=mock_session.id)
         mock_cmd_bar.set_mode.assert_called_once_with("value")
         assert mock_input.value == "500"
 
@@ -1809,7 +1809,7 @@ class TestEditAgentValue:
 
         SessionActionsMixin.action_edit_agent_value(mock_tui)
 
-        mock_cmd_bar.set_target.assert_called_once_with("first-agent")
+        mock_cmd_bar.set_target.assert_called_once_with("first-agent", session_id=mock_session.id)
         assert mock_input.value == "1000"
 
 
@@ -1840,7 +1840,7 @@ class TestConfigureHeartbeat:
 
         SessionActionsMixin.action_configure_heartbeat(mock_tui)
 
-        mock_cmd_bar.set_target.assert_called_once_with("test-agent")
+        mock_cmd_bar.set_target.assert_called_once_with("test-agent", session_id=mock_session.id)
         mock_cmd_bar.set_mode.assert_called_once_with("heartbeat_freq")
         assert mock_input.value == "600"
 


### PR DESCRIPTION
## Summary

- Thread `session_id` alongside `session_name` through the entire command bar flow so all operations resolve the correct agent by unique ID
- Add `send_to_session_by_id()` to launcher for unambiguous tmux key sending
- Add `_find_any_session_by_id()` and `_resolve_command_bar_session()` helpers to TUI
- Fix heartbeat prefill lookups to search `app.sessions` by ID instead of local-only `get_session_by_name()`

**Root cause**: The command bar stored only `target_session` (name). `_find_any_session_by_name()` checked local sessions first, so a local agent always won over a remote one with the same name. This affected all command bar operations: inject, standing orders, value, budget, annotation, and heartbeat.

## Test plan

- [x] All 3042 unit tests pass (`pytest tests/unit/ -x -q`)
- [ ] Manual: launch local agent "foo", connect sister with agent "foo", focus remote "foo", press `i`, send instruction — verify it goes to remote
- [ ] Verify standing orders, value, budget, annotation, heartbeat all target correct agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)