### PR TITLE
Add coverage JSON and generated docs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 .claude/settings.local.json
 .coverage
 .coverage.*
+coverage*.json
 .DS_Store
 .eggs/
 .idea/
@@ -57,6 +58,10 @@ tmp/
 var/
 venv/
 wheels/
+
+# Generated architecture diagrams
+docs/architecture-*.svg
+docs/architecture-*.pdf
 
 # Environment files with secrets
 .env


### PR DESCRIPTION
## Summary
- Add `coverage*.json` to ignore coverage report artifacts
- Add `docs/architecture-*.svg` and `docs/architecture-*.pdf` to ignore generated diagrams

Cleans up 10 untracked files from `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)