### PR TITLE
Fix $0 cost for agents launched with relative start_directory

### DIFF
--- a/src/overcode/launcher.py
+++ b/src/overcode/launcher.py
@@ -11,6 +11,7 @@ import time
 import subprocess
 import os
 import shlex
+from pathlib import Path
 from typing import List, Optional
 
 import re
@@ -203,12 +204,14 @@ class ClaudeLauncher:
 
         # Register session with default standing instructions from config
         default_instructions = get_default_standing_instructions()
+        # Resolve to absolute path so daemon/CLI don't disagree on CWD (#312)
+        resolved_directory = str(Path(start_directory).resolve()) if start_directory else None
         session = self.sessions.create_session(
             name=name,
             tmux_session=self.tmux.session_name,
             tmux_window=window_index,
             command=claude_cmd,
-            start_directory=start_directory,
+            start_directory=resolved_directory,
             standing_instructions=default_instructions,
             permissiveness_mode=perm_mode,
             allowed_tools=allowed_tools,


### PR DESCRIPTION
## Summary

- Resolve `start_directory` to an absolute path at launch time in `launcher.py`, so the monitor daemon, CLI, TUI, and web API all agree on the directory

## Problem

When an agent is launched with a relative path (e.g. `overcode launch kipper -d .`), the path `"."` is stored verbatim in session state. The monitor daemon later resolves this relative to **its own CWD** — not the original launch directory — causing:

1. **Session ID detection fails**: `sync_session_id()` resolves `"."` → daemon's CWD → no matching history entries → `claude_session_ids` stays `[]`
2. **Token/cost sync finds nothing**: `get_session_stats()` gets 0 interactions → 0 tokens → `calculate_cost_estimate(0,0,0,0)` = **$0.00**
3. **CLI shows wrong tokens**: `overcode list` resolves `"."` relative to the user's CWD, accidentally matching another agent's directory and displaying its token count

## Fix

One-line change: resolve `start_directory` to absolute via `Path(...).resolve()` before persisting in `launcher.py`. All downstream consumers already call `Path(...).resolve()` — the bug was that the stored value was relative, so each consumer resolved it differently.

## Test plan

- [x] All 53 launcher tests pass
- [x] All 96 monitor daemon + history reader tests pass
- [ ] Manual: launch agent with `-d .`, verify `sessions.json` stores absolute path
- [ ] Manual: verify `overcode list --cost` shows correct cost for the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)