### PR TITLE
Fix modal focus stealing with generic _any_modal_visible()

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -717,6 +717,8 @@ class SupervisorTUI(
         """Auto-focus the widget at the new index, update preview, and sync tmux."""
         if self._suppress_focus_watcher:
             return
+        if self._any_modal_visible():
+            return
         widget = self._get_focused_widget()
         if widget is None:
             return


### PR DESCRIPTION
## Summary
- Fix focus being stolen from modals (NewAgentDefaultsModal, SummaryConfigModal) by two separate code paths
- Add `_any_modal_visible()` helper that queries `.modal.visible` generically — no more hardcoded per-modal checks
- Modals get `classes="modal"` in `compose()` so future modals get focus protection + key blocking for free

## Root cause
Two focus-stealing paths:
1. `_should_recover_focus()` — called on every keypress and every 250ms timer tick. Had a hardcoded list that missed the new modal.
2. `watch_focused_session_index` — reactive watcher fires when status updates clamp the index, calls `widget.focus()` unconditionally.

Both now bail early via `_any_modal_visible()`.

## Test plan
- [x] `pytest tests/unit/ -x` — 3067 passed
- [ ] Open column config modal (`C`) — stays focused, keys work
- [ ] Open agent defaults modal (`G`) — stays focused, keys work

🤖 Generated with [Claude Code](https://claude.com/claude-code)