### PR TITLE
Fix PR flicker and column misalignment with structural safeguards

### DIFF
--- a/src/overcode/status_patterns.py
+++ b/src/overcode/status_patterns.py
@@ -12,7 +12,7 @@ Each pattern set includes documentation about when it's used and what it matches
 
 import re
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Optional
 
 # Regex to match ANSI escape sequences (colors, cursor movement, etc.)
 ANSI_ESCAPE_PATTERN = re.compile(r'\x1b\[[0-9;]*[a-zA-Z]')
@@ -512,3 +512,35 @@ def is_sleep_command(text: str) -> bool:
         True if the text contains a sleep command
     """
     return bool(_SLEEP_PATTERN.search(text))
+
+
+@dataclass
+class PaneExtraction:
+    """All display-relevant values extracted from pane content.
+
+    This is the return type of extract_from_pane(). Keeping extractions in a
+    pure dataclass prevents accidental mutation of session objects (Pattern B
+    anti-pattern) and forces new extractions to follow the widget-var pattern.
+    """
+    background_bash_count: int = 0
+    live_subagent_count: int = 0
+    pr_number: Optional[int] = None
+
+
+def extract_from_pane(content: str) -> PaneExtraction:
+    """Pure function: extract all display-relevant data from pane content.
+
+    Returns a PaneExtraction dataclass. Results should be stored as widget
+    instance variables, never written to session objects.
+
+    Args:
+        content: Raw pane content (may include ANSI codes)
+
+    Returns:
+        PaneExtraction with all extracted values
+    """
+    return PaneExtraction(
+        background_bash_count=extract_background_bash_count(content),
+        live_subagent_count=extract_live_subagent_count(content),
+        pr_number=extract_pr_number(content),
+    )

--- a/src/overcode/tui_logic.py
+++ b/src/overcode/tui_logic.py
@@ -634,8 +634,8 @@ def detect_display_changes(
     sessions: List,
     any_has_budget: bool,
     any_has_oversight: bool,
-) -> Tuple[bool, bool]:
-    """Compute budget and oversight flag changes from sessions.
+) -> Tuple[bool, bool, bool]:
+    """Compute budget, oversight, and PR flag changes from sessions.
 
     Pure function — no side effects, fully testable.
 
@@ -645,7 +645,7 @@ def detect_display_changes(
         any_has_oversight: Current value of any_has_oversight flag
 
     Returns:
-        Tuple of (new_any_has_budget, new_any_has_oversight)
+        Tuple of (new_any_has_budget, new_any_has_oversight, new_any_has_pr)
     """
     new_budget = any(getattr(s, 'cost_budget_usd', 0) > 0 for s in sessions)
     new_oversight = any(
@@ -653,7 +653,8 @@ def detect_display_changes(
         and getattr(s, 'oversight_timeout_seconds', 0) > 0
         for s in sessions
     )
-    return new_budget, new_oversight
+    new_pr = any(getattr(s, 'pr_number', None) is not None for s in sessions)
+    return new_budget, new_oversight, new_pr
 
 
 def compute_active_session_names(

--- a/tests/unit/test_session_summary.py
+++ b/tests/unit/test_session_summary.py
@@ -90,6 +90,8 @@ def _make_bare_widget(**extra_attrs) -> SessionSummary:
     widget.git_diff_stats = None
     widget.background_bash_count = 0
     widget.live_subagent_count = 0
+    widget.pr_number = None
+    widget.any_has_pr = False
     widget.is_unvisited_stalled = False
     widget.monochrome = False
     widget.show_cost = False
@@ -350,10 +352,13 @@ class TestApplyStatusNoRefresh:
         widget.apply_status_no_refresh("running", "", "", None, None)
         assert widget.git_diff_stats == (3, 50, 10)
 
-    @patch("overcode.tui_widgets.session_summary.extract_background_bash_count", return_value=3)
-    @patch("overcode.tui_widgets.session_summary.extract_live_subagent_count", return_value=2)
-    def test_extracts_live_counts_from_content(self, mock_sub, mock_bash):
+    @patch("overcode.tui_widgets.session_summary.extract_from_pane")
+    def test_extracts_live_counts_from_content(self, mock_extract):
         """Background bash and subagent counts are extracted from content."""
+        from overcode.status_patterns import PaneExtraction
+        mock_extract.return_value = PaneExtraction(
+            background_bash_count=3, live_subagent_count=2, pr_number=None,
+        )
         widget = _make_bare_widget()
         widget.apply_status_no_refresh("running", "", "some pane content", None, None)
         assert widget.background_bash_count == 3

--- a/tests/unit/test_tui_logic.py
+++ b/tests/unit/test_tui_logic.py
@@ -1077,31 +1077,50 @@ class TestDetectDisplayChanges:
     """Tests for detect_display_changes()."""
 
     def test_no_budget_no_oversight(self):
-        """Should return False, False when no budget/oversight."""
-        sessions = [Mock(cost_budget_usd=0, oversight_policy="wait", oversight_timeout_seconds=0)]
-        budget, oversight = detect_display_changes(sessions, False, False)
+        """Should return False, False, False when no budget/oversight/pr."""
+        sessions = [Mock(cost_budget_usd=0, oversight_policy="wait", oversight_timeout_seconds=0, pr_number=None)]
+        budget, oversight, pr = detect_display_changes(sessions, False, False)
         assert budget is False
         assert oversight is False
+        assert pr is False
 
     def test_has_budget(self):
         """Should detect cost budget."""
-        sessions = [Mock(cost_budget_usd=5.0, oversight_policy="wait", oversight_timeout_seconds=0)]
-        budget, oversight = detect_display_changes(sessions, False, False)
+        sessions = [Mock(cost_budget_usd=5.0, oversight_policy="wait", oversight_timeout_seconds=0, pr_number=None)]
+        budget, oversight, pr = detect_display_changes(sessions, False, False)
         assert budget is True
         assert oversight is False
 
     def test_has_oversight(self):
         """Should detect oversight timeout."""
-        sessions = [Mock(cost_budget_usd=0, oversight_policy="timeout", oversight_timeout_seconds=300)]
-        budget, oversight = detect_display_changes(sessions, False, False)
+        sessions = [Mock(cost_budget_usd=0, oversight_policy="timeout", oversight_timeout_seconds=300, pr_number=None)]
+        budget, oversight, pr = detect_display_changes(sessions, False, False)
         assert budget is False
         assert oversight is True
 
     def test_empty_sessions(self):
-        """Should return False, False for empty sessions."""
-        budget, oversight = detect_display_changes([], False, False)
+        """Should return False, False, False for empty sessions."""
+        budget, oversight, pr = detect_display_changes([], False, False)
         assert budget is False
         assert oversight is False
+        assert pr is False
+
+    def test_has_pr(self):
+        """Should detect PR number."""
+        sessions = [Mock(cost_budget_usd=0, oversight_policy="wait", oversight_timeout_seconds=0, pr_number=42)]
+        budget, oversight, pr = detect_display_changes(sessions, False, False)
+        assert budget is False
+        assert oversight is False
+        assert pr is True
+
+    def test_no_pr_when_none(self):
+        """Should not detect PR when all are None."""
+        sessions = [
+            Mock(cost_budget_usd=0, oversight_policy="wait", oversight_timeout_seconds=0, pr_number=None),
+            Mock(cost_budget_usd=0, oversight_policy="wait", oversight_timeout_seconds=0, pr_number=None),
+        ]
+        _, _, pr = detect_display_changes(sessions, False, False)
+        assert pr is False
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- **Anti-flicker**: Add `extract_from_pane()` pure function + `PaneExtraction` dataclass that forces pane extractions into widget variables (Pattern A), preventing the session-mutation pattern (Pattern B) that caused PR number flicker when `widget.session` was replaced from disk
- **Anti-misalignment**: Add `visible` callback + `placeholder_width` to `SummaryColumn` so the rendering framework handles column alignment automatically, replacing manual placeholder logic in `render_budget`, `render_oversight_countdown`, and `render_sleep_countdown`
- **3-tuple from `detect_display_changes`**: Now returns `(any_has_budget, any_has_oversight, any_has_pr)` so TUI can propagate PR visibility to all widgets

## Test plan

- [x] All 3075 unit tests pass (0 failures, 11 pre-existing skips)
- [ ] Manual: launch agents, one creates PR → PR# appears, others get aligned placeholder
- [ ] Manual: kill and restart TUI → PR# persists from session data
- [ ] Manual: PR URL scrolls off pane → PR# stays (sticky widget var)
- [ ] Manual: verify budget/oversight/sleep columns still align correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)