### PR TITLE
Simplify daemon state serialization, single-pass file reading, faster loop

### DIFF
--- a/src/overcode/history_reader.py
+++ b/src/overcode/history_reader.py
@@ -404,31 +404,35 @@ def get_session_file_path(
     return projects_path / encoded / f"{session_id}.jsonl"
 
 
-def read_token_usage_from_session_file(
+def read_session_file_stats(
     session_file: Path,
-    since: Optional[datetime] = None
-) -> dict:
-    """Read token usage from a Claude Code session JSONL file.
+    since: Optional[datetime] = None,
+) -> Tuple[dict, List[float]]:
+    """Read token usage and work times from a session file in a single pass.
+
+    Combines the work of read_token_usage_from_session_file and
+    read_work_times_from_session_file so the file is only read once.
 
     Args:
         session_file: Path to the session JSONL file
-        since: Only count tokens from messages after this time
+        since: Only count data from messages after this time
 
     Returns:
-        Dict with input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-        and current_context_tokens (most recent input_tokens value)
+        (token_usage_dict, work_times_list)
     """
     totals = {
         "input_tokens": 0,
         "output_tokens": 0,
         "cache_creation_tokens": 0,
         "cache_read_tokens": 0,
-        "current_context_tokens": 0,  # Most recent input_tokens
-        "model": None,  # Most recently seen model name (#272)
+        "current_context_tokens": 0,
+        "model": None,
     }
 
     if not session_file.exists():
-        return totals
+        return totals, []
+
+    user_prompt_times: List[datetime] = []
 
     try:
         with open(session_file, 'r') as f:
@@ -438,14 +442,14 @@ def read_token_usage_from_session_file(
                     continue
                 try:
                     data = json.loads(line)
-                    # Only assistant messages have usage data
-                    if data.get("type") == "assistant":
+                    msg_type = data.get("type")
+
+                    if msg_type == "assistant":
                         # Check timestamp if filtering by time
                         if since:
                             ts_str = data.get("timestamp")
                             if ts_str:
                                 try:
-                                    # Parse ISO timestamp (e.g., "2026-01-02T06:56:01.975Z")
                                     msg_time = datetime.fromisoformat(
                                         ts_str.replace("Z", "+00:00")
                                     ).replace(tzinfo=None)
@@ -468,15 +472,62 @@ def read_token_usage_from_session_file(
                                 "cache_creation_input_tokens", 0
                             )
                             totals["cache_read_tokens"] += cache_read
-                            # Track most recent context size (input + cached context)
                             context_size = input_tokens + cache_read
                             if context_size > 0:
                                 totals["current_context_tokens"] = context_size
+
+                    elif msg_type == "user":
+                        # Check if this is an actual user prompt (not a tool result)
+                        message = data.get("message", {})
+                        content = message.get("content", "")
+                        if isinstance(content, list):
+                            if content and content[0].get("type") == "tool_result":
+                                continue
+
+                        ts_str = data.get("timestamp")
+                        if not ts_str:
+                            continue
+
+                        try:
+                            msg_time = datetime.fromisoformat(
+                                ts_str.replace("Z", "+00:00")
+                            ).replace(tzinfo=None)
+                            if since and msg_time < since:
+                                continue
+                            user_prompt_times.append(msg_time)
+                        except (ValueError, TypeError):
+                            continue
+
                 except (json.JSONDecodeError, KeyError, TypeError):
                     continue
     except IOError:
-        pass
+        return totals, []
 
+    # Calculate durations between consecutive prompts
+    work_times = []
+    for i in range(1, len(user_prompt_times)):
+        duration = (user_prompt_times[i] - user_prompt_times[i - 1]).total_seconds()
+        if duration > 0:
+            work_times.append(duration)
+
+    return totals, work_times
+
+
+def read_token_usage_from_session_file(
+    session_file: Path,
+    since: Optional[datetime] = None
+) -> dict:
+    """Read token usage from a Claude Code session JSONL file.
+
+    Args:
+        session_file: Path to the session JSONL file
+        since: Only count tokens from messages after this time
+
+    Returns:
+        Dict with input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+        and current_context_tokens (most recent input_tokens value)
+    """
+    totals, _ = read_session_file_stats(session_file, since)
     return totals
 
 
@@ -498,62 +549,7 @@ def read_work_times_from_session_file(
     Returns:
         List of work times in seconds
     """
-    if not session_file.exists():
-        return []
-
-    user_prompt_times: List[datetime] = []
-
-    try:
-        with open(session_file, 'r') as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    data = json.loads(line)
-                    if data.get("type") != "user":
-                        continue
-
-                    # Check if this is an actual user prompt (not a tool result)
-                    message = data.get("message", {})
-                    content = message.get("content", "")
-
-                    # Tool results have content as a list with tool_result type
-                    if isinstance(content, list):
-                        # Check if it's a tool result
-                        if content and content[0].get("type") == "tool_result":
-                            continue
-
-                    # Parse timestamp
-                    ts_str = data.get("timestamp")
-                    if not ts_str:
-                        continue
-
-                    try:
-                        msg_time = datetime.fromisoformat(
-                            ts_str.replace("Z", "+00:00")
-                        ).replace(tzinfo=None)
-
-                        # Filter by since time
-                        if since and msg_time < since:
-                            continue
-
-                        user_prompt_times.append(msg_time)
-                    except (ValueError, TypeError):
-                        continue
-
-                except (json.JSONDecodeError, KeyError, TypeError):
-                    continue
-    except IOError:
-        return []
-
-    # Calculate durations between consecutive prompts
-    work_times = []
-    for i in range(1, len(user_prompt_times)):
-        duration = (user_prompt_times[i] - user_prompt_times[i - 1]).total_seconds()
-        if duration > 0:
-            work_times.append(duration)
-
+    _, work_times = read_session_file_stats(session_file, since)
     return work_times
 
 
@@ -625,7 +621,7 @@ def get_session_stats(
         session_file = get_session_file_path(
             session.start_directory, sid, projects_path
         )
-        usage = read_token_usage_from_session_file(session_file, since=session_start)
+        usage, work_times = read_session_file_stats(session_file, since=session_start)
         total_input += usage["input_tokens"]
         total_output += usage["output_tokens"]
         total_cache_creation += usage["cache_creation_tokens"]
@@ -644,7 +640,6 @@ def get_session_stats(
                 detected_model = usage["model"]
 
         # Collect work times from this session file
-        work_times = read_work_times_from_session_file(session_file, since=session_start)
         all_work_times.extend(work_times)
 
         # Check for subagent files in {sessionId}/subagents/
@@ -655,7 +650,7 @@ def get_session_stats(
                 subagent_count += 1
                 if now - subagent_file.stat().st_mtime < 30:
                     live_subagent_count += 1
-                sub_usage = read_token_usage_from_session_file(
+                sub_usage, _ = read_session_file_stats(
                     subagent_file, since=session_start
                 )
                 total_input += sub_usage["input_tokens"]

--- a/src/overcode/monitor_daemon.py
+++ b/src/overcode/monitor_daemon.py
@@ -192,7 +192,7 @@ class PresenceComponent:
             self._last_publish_time = now
             return False
         gap = (now - self._last_publish_time).total_seconds()
-        slept = gap > 2 * DAEMON.interval_fast
+        slept = gap > 20  # Machine sleep produces gaps of 30s+; absolute threshold avoids false positives
         self._last_publish_time = now
         return slept
 
@@ -638,7 +638,7 @@ class MonitorDaemon:
 
     def _interruptible_sleep(self, total_seconds: int) -> None:
         """Sleep with activity signal checking."""
-        chunk_size = 10
+        chunk_size = 1
         elapsed = 0
 
         while elapsed < total_seconds and not self._shutdown:

--- a/src/overcode/monitor_daemon_state.py
+++ b/src/overcode/monitor_daemon_state.py
@@ -14,6 +14,7 @@ The Monitor Daemon is the single source of truth for:
 import json
 import os
 import tempfile
+import dataclasses
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -109,114 +110,14 @@ class SessionDaemonState:
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
-        return {
-            "session_id": self.session_id,
-            "name": self.name,
-            "tmux_window": self.tmux_window,
-            "current_status": self.current_status,
-            "current_activity": self.current_activity,
-            "status_since": self.status_since,
-            "green_time_seconds": self.green_time_seconds,
-            "non_green_time_seconds": self.non_green_time_seconds,
-            "sleep_time_seconds": self.sleep_time_seconds,
-            "interaction_count": self.interaction_count,
-            "input_tokens": self.input_tokens,
-            "output_tokens": self.output_tokens,
-            "cache_creation_tokens": self.cache_creation_tokens,
-            "cache_read_tokens": self.cache_read_tokens,
-            "estimated_cost_usd": self.estimated_cost_usd,
-            "median_work_time": self.median_work_time,
-            "repo_name": self.repo_name,
-            "branch": self.branch,
-            "standing_instructions": self.standing_instructions,
-            "standing_orders_complete": self.standing_orders_complete,
-            "steers_count": self.steers_count,
-            "start_time": self.start_time,
-            "permissiveness_mode": self.permissiveness_mode,
-            "start_directory": self.start_directory,
-            "is_asleep": self.is_asleep,
-            "time_context_enabled": self.time_context_enabled,
-            "agent_value": self.agent_value,
-            "activity_summary": self.activity_summary,
-            "activity_summary_updated": self.activity_summary_updated,
-            "activity_summary_context": self.activity_summary_context,
-            "activity_summary_context_updated": self.activity_summary_context_updated,
-            # Heartbeat state (#171)
-            "heartbeat_enabled": self.heartbeat_enabled,
-            "heartbeat_frequency_seconds": self.heartbeat_frequency_seconds,
-            "heartbeat_paused": self.heartbeat_paused,
-            "last_heartbeat_time": self.last_heartbeat_time,
-            "next_heartbeat_due": self.next_heartbeat_due,
-            "running_from_heartbeat": self.running_from_heartbeat,
-            "waiting_for_heartbeat": self.waiting_for_heartbeat,
-            # Cost budget (#173)
-            "cost_budget_usd": self.cost_budget_usd,
-            "budget_exceeded": self.budget_exceeded,
-            # Agent hierarchy (#244)
-            "parent_name": self.parent_name,
-            "depth": self.depth,
-            "children_count": self.children_count,
-            # Oversight system
-            "oversight_policy": self.oversight_policy,
-            "oversight_timeout_seconds": self.oversight_timeout_seconds,
-            "oversight_deadline": self.oversight_deadline,
-        }
+        return dataclasses.asdict(self)
 
     @classmethod
     def from_dict(cls, data: dict) -> "SessionDaemonState":
-        """Create from dictionary."""
-        return cls(
-            session_id=data.get("session_id", ""),
-            name=data.get("name", ""),
-            tmux_window=data.get("tmux_window", 0),
-            current_status=data.get("current_status", "unknown"),
-            current_activity=data.get("current_activity", ""),
-            status_since=data.get("status_since"),
-            green_time_seconds=data.get("green_time_seconds", 0.0),
-            non_green_time_seconds=data.get("non_green_time_seconds", 0.0),
-            sleep_time_seconds=data.get("sleep_time_seconds", 0.0),
-            interaction_count=data.get("interaction_count", 0),
-            input_tokens=data.get("input_tokens", 0),
-            output_tokens=data.get("output_tokens", 0),
-            cache_creation_tokens=data.get("cache_creation_tokens", 0),
-            cache_read_tokens=data.get("cache_read_tokens", 0),
-            estimated_cost_usd=data.get("estimated_cost_usd", 0.0),
-            median_work_time=data.get("median_work_time", 0.0),
-            repo_name=data.get("repo_name"),
-            branch=data.get("branch"),
-            standing_instructions=data.get("standing_instructions", ""),
-            standing_orders_complete=data.get("standing_orders_complete", False),
-            steers_count=data.get("steers_count", 0),
-            start_time=data.get("start_time"),
-            permissiveness_mode=data.get("permissiveness_mode", "normal"),
-            start_directory=data.get("start_directory"),
-            is_asleep=data.get("is_asleep", False),
-            time_context_enabled=data.get("time_context_enabled", False),
-            agent_value=data.get("agent_value", 1000),
-            activity_summary=data.get("activity_summary", ""),
-            activity_summary_updated=data.get("activity_summary_updated"),
-            activity_summary_context=data.get("activity_summary_context", ""),
-            activity_summary_context_updated=data.get("activity_summary_context_updated"),
-            # Heartbeat state (#171)
-            heartbeat_enabled=data.get("heartbeat_enabled", False),
-            heartbeat_frequency_seconds=data.get("heartbeat_frequency_seconds", 300),
-            heartbeat_paused=data.get("heartbeat_paused", False),
-            last_heartbeat_time=data.get("last_heartbeat_time"),
-            next_heartbeat_due=data.get("next_heartbeat_due"),
-            running_from_heartbeat=data.get("running_from_heartbeat", False),
-            waiting_for_heartbeat=data.get("waiting_for_heartbeat", False),
-            # Cost budget (#173)
-            cost_budget_usd=data.get("cost_budget_usd", 0.0),
-            budget_exceeded=data.get("budget_exceeded", False),
-            # Agent hierarchy (#244)
-            parent_name=data.get("parent_name"),
-            depth=data.get("depth", 0),
-            children_count=data.get("children_count", 0),
-            # Oversight system
-            oversight_policy=data.get("oversight_policy", "wait"),
-            oversight_timeout_seconds=data.get("oversight_timeout_seconds", 0.0),
-            oversight_deadline=data.get("oversight_deadline"),
-        )
+        """Create from dictionary, ignoring unknown keys."""
+        fields = {f.name for f in dataclasses.fields(cls)}
+        known = {k: v for k, v in data.items() if k in fields}
+        return cls(**known)
 
 
 @dataclass
@@ -274,37 +175,7 @@ class MonitorDaemonState:
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
-        return {
-            "pid": self.pid,
-            "status": self.status,
-            "loop_count": self.loop_count,
-            "current_interval": self.current_interval,
-            "last_loop_time": self.last_loop_time,
-            "started_at": self.started_at,
-            "daemon_version": self.daemon_version,
-            "sessions": [s.to_dict() for s in self.sessions],
-            "presence_available": self.presence_available,
-            "presence_state": self.presence_state,
-            "presence_idle_seconds": self.presence_idle_seconds,
-            "total_green_time": self.total_green_time,
-            "total_non_green_time": self.total_non_green_time,
-            "total_sleep_time": self.total_sleep_time,
-            "green_sessions": self.green_sessions,
-            "non_green_sessions": self.non_green_sessions,
-            "total_supervisions": self.total_supervisions,
-            "supervisor_launches": self.supervisor_launches,
-            "supervisor_tokens": self.supervisor_tokens,
-            "supervisor_claude_running": self.supervisor_claude_running,
-            "supervisor_claude_started_at": self.supervisor_claude_started_at,
-            "supervisor_claude_total_run_seconds": self.supervisor_claude_total_run_seconds,
-            "summarizer_enabled": self.summarizer_enabled,
-            "summarizer_available": self.summarizer_available,
-            "summarizer_calls": self.summarizer_calls,
-            "summarizer_cost_usd": self.summarizer_cost_usd,
-            "relay_enabled": self.relay_enabled,
-            "relay_last_push": self.relay_last_push,
-            "relay_last_status": self.relay_last_status,
-        }
+        return dataclasses.asdict(self)
 
     @classmethod
     def from_dict(cls, data: dict) -> "MonitorDaemonState":
@@ -313,38 +184,9 @@ class MonitorDaemonState:
             SessionDaemonState.from_dict(s)
             for s in data.get("sessions", [])
         ]
-
-        return cls(
-            pid=data.get("pid", 0),
-            status=data.get("status", "stopped"),
-            loop_count=data.get("loop_count", 0),
-            current_interval=data.get("current_interval", DAEMON.interval_fast),
-            last_loop_time=data.get("last_loop_time"),
-            started_at=data.get("started_at"),
-            daemon_version=data.get("daemon_version", 0),
-            sessions=sessions,
-            presence_available=data.get("presence_available", False),
-            presence_state=data.get("presence_state"),
-            presence_idle_seconds=data.get("presence_idle_seconds"),
-            total_green_time=data.get("total_green_time", 0.0),
-            total_non_green_time=data.get("total_non_green_time", 0.0),
-            total_sleep_time=data.get("total_sleep_time", 0.0),
-            green_sessions=data.get("green_sessions", 0),
-            non_green_sessions=data.get("non_green_sessions", 0),
-            total_supervisions=data.get("total_supervisions", 0),
-            supervisor_launches=data.get("supervisor_launches", 0),
-            supervisor_tokens=data.get("supervisor_tokens", 0),
-            supervisor_claude_running=data.get("supervisor_claude_running", False),
-            supervisor_claude_started_at=data.get("supervisor_claude_started_at"),
-            supervisor_claude_total_run_seconds=data.get("supervisor_claude_total_run_seconds", 0.0),
-            summarizer_enabled=data.get("summarizer_enabled", False),
-            summarizer_available=data.get("summarizer_available", False),
-            summarizer_calls=data.get("summarizer_calls", 0),
-            summarizer_cost_usd=data.get("summarizer_cost_usd", 0.0),
-            relay_enabled=data.get("relay_enabled", False),
-            relay_last_push=data.get("relay_last_push"),
-            relay_last_status=data.get("relay_last_status", "disabled"),
-        )
+        fields = {f.name for f in dataclasses.fields(cls)}
+        known = {k: v for k, v in data.items() if k in fields and k != "sessions"}
+        return cls(sessions=sessions, **known)
 
     def update_summaries(self) -> None:
         """Recompute summary metrics from session data."""

--- a/src/overcode/settings.py
+++ b/src/overcode/settings.py
@@ -152,7 +152,7 @@ class DaemonSettings:
     """Settings for the daemon."""
 
     # Polling intervals (seconds)
-    interval_fast: int = 10      # When active or agents working
+    interval_fast: int = 2       # When active or agents working
     interval_slow: int = 300     # When all agents need user input (5 min)
     interval_idle: int = 3600    # When no agents at all (1 hour)
 

--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -430,7 +430,7 @@ class SupervisorTUI(
             # Slow stats updates every 5s (claude stats + git diff — heavy file I/O)
             # Stagger the three 5s timers so background work doesn't burst all at once
             self.set_interval(5, self._update_stats_async)
-            self.set_timer(1.7, lambda: self.set_interval(5, self.update_daemon_status))
+            self.set_timer(1.7, lambda: self.set_interval(1, self.update_daemon_status))
             # Update timeline every 30 seconds
             self.set_interval(30, self.update_timeline)
             # Update AI summaries every 5 seconds (only runs if enabled)
@@ -789,38 +789,38 @@ class SupervisorTUI(
             for (session_id, _), status_result in zip(sessions_to_check, results):
                 status_results[session_id] = status_result
 
-            # Enrich status with heartbeat info from daemon state (#171)
+            # Enrich non-focused agents with daemon state (#291)
+            # The focused agent keeps its detect_status result for preview pane
+            # responsiveness. Non-focused agents use daemon's current_status
+            # directly when available and fresh (< 5s old), which includes
+            # heartbeat, oversight, and other enrichments already applied by
+            # the daemon.
+            focused_widget = self._get_focused_widget()
+            focused_id = focused_widget.session.id if focused_widget else None
             daemon_state = get_monitor_daemon_state(self.tmux_session)
-            if daemon_state and daemon_state.sessions:
-                heartbeat_sessions = {
-                    s.session_id for s in daemon_state.sessions
-                    if s.running_from_heartbeat
-                }
-                for session_id in heartbeat_sessions:
-                    if session_id in status_results:
-                        status, activity, content = status_results[session_id]
-                        if status == STATUS_RUNNING:
-                            status_results[session_id] = (STATUS_RUNNING_HEARTBEAT, activity, content)
-
-                waiting_heartbeat_sessions = {
-                    s.session_id for s in daemon_state.sessions
-                    if s.waiting_for_heartbeat
-                }
-                for session_id in waiting_heartbeat_sessions:
-                    if session_id in status_results:
-                        status, activity, content = status_results[session_id]
-                        if status not in (STATUS_RUNNING, STATUS_RUNNING_HEARTBEAT):
-                            status_results[session_id] = (STATUS_WAITING_HEARTBEAT, activity, content)
-
-                # Enrich with waiting_oversight from daemon state
-                oversight_sessions = {
-                    s.session_id: s for s in daemon_state.sessions
-                    if s.current_status == STATUS_WAITING_OVERSIGHT
-                }
-                for session_id, ds in oversight_sessions.items():
-                    if session_id in status_results:
-                        _, _, content = status_results[session_id]
-                        status_results[session_id] = (STATUS_WAITING_OVERSIGHT, "Waiting for oversight report", content)
+            if daemon_state and daemon_state.sessions and not daemon_state.is_stale(buffer_seconds=5.0):
+                daemon_by_id = {s.session_id: s for s in daemon_state.sessions}
+                for session_id in list(status_results):
+                    if session_id == focused_id:
+                        # Focused agent: still enrich with heartbeat/oversight
+                        # from daemon (detect_status can't see these)
+                        ds = daemon_by_id.get(session_id)
+                        if ds:
+                            status, activity, content = status_results[session_id]
+                            if ds.running_from_heartbeat and status == STATUS_RUNNING:
+                                status = STATUS_RUNNING_HEARTBEAT
+                            elif ds.waiting_for_heartbeat and status not in (STATUS_RUNNING, STATUS_RUNNING_HEARTBEAT):
+                                status = STATUS_WAITING_HEARTBEAT
+                            elif ds.current_status == STATUS_WAITING_OVERSIGHT:
+                                status = STATUS_WAITING_OVERSIGHT
+                                activity = "Waiting for oversight report"
+                            status_results[session_id] = (status, activity, content)
+                    else:
+                        # Non-focused: use daemon's status directly
+                        ds = daemon_by_id.get(session_id)
+                        if ds:
+                            _, _, content = status_results[session_id]
+                            status_results[session_id] = (ds.current_status, ds.current_activity, content)
 
             # Use local summaries from TUI's summarizer (not daemon state)
             ai_summaries = {}

--- a/tests/unit/test_monitor_daemon.py
+++ b/tests/unit/test_monitor_daemon.py
@@ -903,7 +903,7 @@ class TestInterruptibleSleep:
         with patch('overcode.monitor_daemon.time.sleep', side_effect=track_sleep):
             daemon._interruptible_sleep(30)
 
-        # Should have slept in 10-second chunks: 10 + 10 + 10 = 30
+        # Should have slept in 1-second chunks totaling 30s
         assert sum(sleep_calls) == 30
 
 

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -201,7 +201,7 @@ class TestDaemonSettings:
         from overcode.settings import DaemonSettings
 
         settings = DaemonSettings()
-        assert settings.interval_fast == 10
+        assert settings.interval_fast == 2
         assert settings.interval_slow == 300
         assert settings.interval_idle == 3600
 


### PR DESCRIPTION
## Summary

Three architecture improvements (#293, #295, #291) that reduce code and improve responsiveness:

- **#293 — Kill to_dict/from_dict boilerplate**: Replace 160 lines of manual serialization in `SessionDaemonState` and `MonitorDaemonState` with `dataclasses.asdict()` and a generic `from_dict` that filters by field names. Adding a new field now requires only adding it to the dataclass — no more updating two methods.

- **#295 — Single-pass session file reading**: Combine `read_token_usage_from_session_file` and `read_work_times_from_session_file` into `read_session_file_stats`. Session JSONL files read once per cycle instead of twice. Old functions kept as thin wrappers for backward compat.

- **#291 — Faster daemon loop + fresher TUI reads**: Daemon loop 10s→2s, sleep chunk 10s→1s (activity signals wake within ≤1s), TUI daemon reads 5s→1s. Fix `_detect_sleep` to use absolute 20s threshold (avoids false positives at faster cadence). Simplify TUI enrichment: non-focused agents use daemon's `current_status` directly when fresh; focused agent keeps 250ms detect_status for preview responsiveness.

Net: **-163 lines** across 7 files.

## Test plan

- [x] `uv run pytest tests/unit/ -v` — 304 affected tests pass (all pre-existing TUI flakes unrelated)
- [ ] Start daemon, verify logs show ~2s loop cadence
- [ ] TUI: approve a permission → status updates within 1-2s
- [ ] TUI: press keys → daemon wakes within 1s (check daemon logs)
- [ ] Verify no false positives from `_detect_sleep()` during normal operation
- [ ] Verify daemon state JSON output round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)