### PR TITLE
Fix daemon_state.sessions is a list, not a dict

### DIFF
--- a/src/overcode/cli/agent.py
+++ b/src/overcode/cli/agent.py
@@ -304,7 +304,7 @@ def list_agents(
     if use_daemon:
         any_has_oversight_timeout = any(
             ds.oversight_timeout_seconds > 0
-            for ds in daemon_state.sessions.values()
+            for ds in daemon_state.sessions
         )
     else:
         any_has_oversight_timeout = any(


### PR DESCRIPTION
## Summary
- Fixes `overcode list` crash introduced in #325 — `daemon_state.sessions` is a `list`, not a dict, so `.values()` fails with a live daemon

## Test plan
- [x] `overcode list` works with live agents
- [x] `overcode list --low`, `--med`, `--full` all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)