### PR TITLE
Forward subtree_cost_usd through sister API with daemon_state passthrough

### DIFF
--- a/src/overcode/cli/agent.py
+++ b/src/overcode/cli/agent.py
@@ -322,7 +322,12 @@ def list_agents(
         for ds in daemon_state.sessions:
             if ds.subtree_cost_usd > 0:
                 subtree_costs[ds.session_id] = ds.subtree_cost_usd
-    else:
+    # Also extract from remote sessions via forwarded daemon_state
+    for s in sessions:
+        rds = getattr(s, 'remote_daemon_state', None)
+        if rds and rds.get('subtree_cost_usd', 0) > 0:
+            subtree_costs[s.id] = rds['subtree_cost_usd']
+    if not use_daemon:
         any_has_oversight_timeout = any(
             getattr(s, 'oversight_timeout_seconds', 0) > 0
             for s in sessions

--- a/src/overcode/session_manager.py
+++ b/src/overcode/session_manager.py
@@ -150,6 +150,7 @@ class Session:
     remote_median_work_time: float = 0.0  # Median work time from remote API
     remote_activity_summary: str = ""  # AI summary from remote summarizer
     remote_activity_summary_context: str = ""  # AI context summary from remote summarizer
+    remote_daemon_state: Optional[dict] = None  # Raw daemon state dict from sister API (for generic forwarding)
 
     def to_dict(self) -> dict:
         data = asdict(self)

--- a/src/overcode/sister_poller.py
+++ b/src/overcode/sister_poller.py
@@ -261,6 +261,9 @@ def _agent_to_session(agent: dict, host_name: str, source_url: str = "", source_
         # AI summaries from remote summarizer
         remote_activity_summary=agent.get("activity_summary", ""),
         remote_activity_summary_context=agent.get("activity_summary_context", ""),
+        # Raw daemon state for generic field forwarding — new SessionDaemonState
+        # fields automatically flow through without manual plumbing here.
+        remote_daemon_state=agent.get("daemon_state"),
     )
 
 

--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -865,12 +865,17 @@ class SupervisorTUI(
                             _, _, content = status_results[session_id]
                             status_results[session_id] = (ds.current_status, ds.current_activity, content)
 
-            # Extract subtree costs from daemon state
+            # Extract subtree costs from daemon state (local agents)
             subtree_costs = {}
             if daemon_state and daemon_state.sessions and not daemon_state.is_stale(buffer_seconds=5.0):
                 for ds in daemon_state.sessions:
                     if ds.subtree_cost_usd > 0:
                         subtree_costs[ds.session_id] = ds.subtree_cost_usd
+            # Also extract from remote sessions via forwarded daemon_state
+            for s in self._remote_sessions:
+                rds = getattr(s, 'remote_daemon_state', None)
+                if rds and rds.get('subtree_cost_usd', 0) > 0:
+                    subtree_costs[s.id] = rds['subtree_cost_usd']
 
             # Use local summaries from TUI's summarizer (not daemon state)
             ai_summaries = {}
@@ -1241,13 +1246,18 @@ class SupervisorTUI(
             self.sessions, False, False
         )
 
-        # Read subtree costs from daemon state
+        # Read subtree costs from daemon state (local agents)
         subtree_costs = {}
         daemon_state = get_monitor_daemon_state(self.tmux_session)
         if daemon_state and daemon_state.sessions and not daemon_state.is_stale(buffer_seconds=5.0):
             for ds in daemon_state.sessions:
                 if ds.subtree_cost_usd > 0:
                     subtree_costs[ds.session_id] = ds.subtree_cost_usd
+        # Also extract from remote sessions via forwarded daemon_state
+        for s in self._remote_sessions:
+            rds = getattr(s, 'remote_daemon_state', None)
+            if rds and rds.get('subtree_cost_usd', 0) > 0:
+                subtree_costs[s.id] = rds['subtree_cost_usd']
         any_has_subtree_cost = bool(subtree_costs)
         # Also check widget pr_number vars (sticky — survive session replacement)
         if not any_has_pr:

--- a/src/overcode/web_api.py
+++ b/src/overcode/web_api.py
@@ -289,6 +289,12 @@ def _build_agent_info(s: SessionDaemonState, now: datetime, pane_content: str = 
         "pane_content": pane_content,
         # Agent hierarchy (#244) - for sister tree view
         "parent_name": s.parent_name or "",
+        # Subtree cost (self + all descendants)
+        "subtree_cost_usd": s.subtree_cost_usd,
+        # Raw daemon state — sisters can forward any field without manual mapping.
+        # When adding new fields to SessionDaemonState, they automatically appear
+        # here. The sister poller reads from this dict as a fallback.
+        "daemon_state": s.to_dict(),
     }
 
 


### PR DESCRIPTION
## Summary
- Adds subtree_cost_usd and full daemon_state dict to the /api/status agent response
- Stores remote_daemon_state on the Session dataclass so sister-polled sessions carry the raw daemon state
- TUI and CLI extract subtree_cost_usd from remote_daemon_state for remote sessions
- The daemon_state passthrough means future SessionDaemonState fields automatically flow to sisters without manual plumbing

Follow-up to #329.

## Test plan
- [x] Full test suite passes (3092 passed, 1 pre-existing flaky)
- [ ] Verify remote sisters show subtree costs in TUI/CLI list view