### PR TITLE
Add agent selection modal to launch flow

### DIFF
--- a/src/overcode/agent_scanner.py
+++ b/src/overcode/agent_scanner.py
@@ -1,0 +1,38 @@
+"""
+Scan for Claude Code agent definitions (.md files in .claude/agents/).
+"""
+
+from pathlib import Path
+from typing import List
+
+
+def scan_agents(directory: str) -> List[str]:
+    """Scan for available Claude agent definitions.
+
+    Checks both project-level (.claude/agents/) and user-level (~/.claude/agents/)
+    directories for .md files. Returns deduplicated, sorted list of agent names
+    (filenames without .md extension).
+
+    Args:
+        directory: Project directory to scan for project-level agents.
+
+    Returns:
+        Sorted list of agent names. Empty list if none found.
+    """
+    names: set = set()
+
+    # Project-level agents
+    project_dir = Path(directory) / ".claude" / "agents"
+    if project_dir.is_dir():
+        for f in project_dir.iterdir():
+            if f.is_file() and f.suffix == ".md":
+                names.add(f.stem)
+
+    # User-level agents
+    user_dir = Path.home() / ".claude" / "agents"
+    if user_dir.is_dir():
+        for f in user_dir.iterdir():
+            if f.is_file() and f.suffix == ".md":
+                names.add(f.stem)
+
+    return sorted(names)

--- a/src/overcode/cli/agent.py
+++ b/src/overcode/cli/agent.py
@@ -63,6 +63,10 @@ def launch(
         Optional[float],
         typer.Option("--budget", "-b", help="Cost budget in USD (deducted from parent if parent has budget)"),
     ] = None,
+    agent: Annotated[
+        Optional[str],
+        typer.Option("--agent", "-a", help="Claude agent to run as (from .claude/agents/)"),
+    ] = None,
     teams: Annotated[
         bool,
         typer.Option("--teams", help="Enable Claude Code agent teams (CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS)"),
@@ -164,6 +168,7 @@ def launch(
         extra_claude_args=claude_args,
         agent_teams=teams,
         budget_usd=budget,
+        claude_agent=agent,
     )
 
     if result:
@@ -176,6 +181,8 @@ def launch(
             rprint(f"  Allowed tools: {allowed_tools}")
         if claude_args:
             rprint(f"  Extra Claude args: {' '.join(claude_args)}")
+        if agent:
+            rprint(f"  Agent: {agent}")
         if teams:
             rprint("  Agent teams: enabled")
         if budget is not None and budget > 0:
@@ -878,6 +885,8 @@ def show(
             print(f"{'Tools:':<{label_width + 1}} {sess.allowed_tools}")
         if sess.extra_claude_args:
             print(f"{'Claude args:':<{label_width + 1}} {' '.join(sess.extra_claude_args)}")
+        if sess.claude_agent:
+            print(f"{'Agent:':<{label_width + 1}} {sess.claude_agent}")
         if sess.agent_teams:
             print(f"{'Teams:':<{label_width + 1}} enabled")
 

--- a/src/overcode/launcher.py
+++ b/src/overcode/launcher.py
@@ -80,6 +80,7 @@ class ClaudeLauncher:
         extra_claude_args: Optional[List[str]] = None,
         agent_teams: bool = False,
         budget_usd: Optional[float] = None,
+        claude_agent: Optional[str] = None,
     ) -> Optional[Session]:
         """
         Launch an interactive Claude Code session in a tmux window.
@@ -164,6 +165,10 @@ class ClaudeLauncher:
         elif skip_permissions:
             claude_cmd.extend(["--permission-mode", "dontAsk"])
 
+        # Claude agent persona
+        if claude_agent:
+            claude_cmd.extend(["--agent", claude_agent])
+
         # Claude CLI flag passthrough (#290)
         if allowed_tools:
             claude_cmd.extend(["--allowedTools", allowed_tools])
@@ -218,6 +223,7 @@ class ClaudeLauncher:
             allowed_tools=allowed_tools,
             extra_claude_args=extra_claude_args,
             agent_teams=agent_teams,
+            claude_agent=claude_agent,
         )
 
         # Set parent if launching as child agent (#244)

--- a/src/overcode/session_manager.py
+++ b/src/overcode/session_manager.py
@@ -130,6 +130,7 @@ class Session:
     allowed_tools: Optional[str] = None  # Comma-separated tool list for --allowedTools
     extra_claude_args: List[str] = field(default_factory=list)  # Extra CLI flags via --claude-arg
     agent_teams: bool = False  # Claude Code agent teams mode (#309)
+    claude_agent: Optional[str] = None  # Claude agent persona (from .claude/agents/)
 
     # Agent hierarchy (#244) - parent/child relationships
     parent_session_id: Optional[str] = None  # ID of parent agent (None = root)
@@ -454,7 +455,8 @@ class SessionManager:
                       permissiveness_mode: str = "normal",
                       allowed_tools: Optional[str] = None,
                       extra_claude_args: Optional[List[str]] = None,
-                      agent_teams: bool = False) -> Session:
+                      agent_teams: bool = False,
+                      claude_agent: Optional[str] = None) -> Session:
         """Create and register a new session.
 
         Args:
@@ -488,6 +490,7 @@ class SessionManager:
             allowed_tools=allowed_tools,
             extra_claude_args=extra_claude_args or [],
             agent_teams=agent_teams,
+            claude_agent=claude_agent,
         )
 
         state = self._load_state()

--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -67,6 +67,7 @@ from .tui_widgets import (
     CommandBar,
     SummaryConfigModal,
     NewAgentDefaultsModal,
+    AgentSelectModal,
 )
 from .tui_actions import (
     NavigationActionsMixin,
@@ -349,6 +350,8 @@ class SupervisorTUI(
         yield SummaryConfigModal(id="summary-config-modal", classes="modal")
         # Modal for new-agent defaults
         yield NewAgentDefaultsModal(id="new-agent-defaults-modal", classes="modal")
+        # Modal for agent selection during new agent creation
+        yield AgentSelectModal(id="agent-select-modal", classes="modal")
         yield FullscreenPreview(id="fullscreen-preview")
         yield HelpOverlay(id="help-overlay")
         yield Static(
@@ -1988,10 +1991,12 @@ class SupervisorTUI(
                 start_directory=directory,
                 dangerously_skip_permissions=bypass_permissions,
                 agent_teams=message.agent_teams,
+                claude_agent=message.claude_agent,
             )
             dir_info = f" in {directory}" if directory else ""
             perm_info = " (bypass mode)" if bypass_permissions else ""
-            self.notify(f"Created agent: {agent_name}{dir_info}{perm_info}", severity="information")
+            agent_info = f" (agent: {message.claude_agent})" if message.claude_agent else ""
+            self.notify(f"Created agent: {agent_name}{dir_info}{perm_info}{agent_info}", severity="information")
             # Refresh to show new agent
             self.refresh_sessions()
         except Exception as e:
@@ -2236,6 +2241,26 @@ class SupervisorTUI(
     def on_new_agent_defaults_modal_cancelled(self, message: NewAgentDefaultsModal.Cancelled) -> None:
         """Handle new-agent defaults modal cancellation."""
         pass
+
+    def on_agent_select_modal_agent_selected(self, message: AgentSelectModal.AgentSelected) -> None:
+        """Handle agent selection from modal."""
+        try:
+            cmd_bar = self.query_one("#command-bar", CommandBar)
+            cmd_bar.new_agent_claude_agent = message.agent_name
+            cmd_bar._transition_to_name_step()
+            cmd_bar.focus_input()
+        except NoMatches:
+            pass
+
+    def on_agent_select_modal_agent_select_skipped(self, message: AgentSelectModal.AgentSelectSkipped) -> None:
+        """Handle agent selection skipped (q/Esc)."""
+        try:
+            cmd_bar = self.query_one("#command-bar", CommandBar)
+            cmd_bar.new_agent_claude_agent = None
+            cmd_bar._transition_to_name_step()
+            cmd_bar.focus_input()
+        except NoMatches:
+            pass
 
     # Throttle TUI heartbeat writes to once per 5 seconds
     _last_heartbeat_write: float = 0.0

--- a/src/overcode/tui.tcss
+++ b/src/overcode/tui.tcss
@@ -259,3 +259,19 @@ NewAgentDefaultsModal {
 NewAgentDefaultsModal.visible {
     display: block;
 }
+
+/* Agent Selection Modal */
+AgentSelectModal {
+    display: none;
+    layer: above;
+    offset: 27 30;
+    width: auto;
+    height: auto;
+    background: $surface;
+    border: thick $primary;
+    padding: 1 2;
+}
+
+AgentSelectModal.visible {
+    display: block;
+}

--- a/src/overcode/tui_widgets/__init__.py
+++ b/src/overcode/tui_widgets/__init__.py
@@ -15,6 +15,7 @@ from .session_summary import SessionSummary
 from .command_bar import CommandBar
 from .summary_config_modal import SummaryConfigModal
 from .new_agent_defaults_modal import NewAgentDefaultsModal
+from .agent_select_modal import AgentSelectModal
 
 __all__ = [
     "FullscreenPreview",
@@ -27,4 +28,5 @@ __all__ = [
     "CommandBar",
     "SummaryConfigModal",
     "NewAgentDefaultsModal",
+    "AgentSelectModal",
 ]

--- a/src/overcode/tui_widgets/agent_select_modal.py
+++ b/src/overcode/tui_widgets/agent_select_modal.py
@@ -1,0 +1,126 @@
+"""
+Agent selection modal for TUI.
+
+Keyboard-navigable list to pick a Claude agent persona before launching.
+"""
+
+from typing import List, Optional, Any
+
+from textual.widgets import Static
+from textual.message import Message
+from textual import events
+from rich.text import Text
+
+
+class AgentSelectModal(Static, can_focus=True):
+    """Modal dialog for selecting a Claude agent.
+
+    Navigate with j/k or up/down arrows.
+    Press Enter to select, q/Esc to skip (default Claude).
+    """
+
+    class AgentSelected(Message):
+        """Message sent when an agent is selected."""
+
+        def __init__(self, agent_name: Optional[str]) -> None:
+            super().__init__()
+            self.agent_name = agent_name
+
+    class AgentSelectSkipped(Message):
+        """Message sent when agent selection is skipped."""
+        pass
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._agents: List[str] = []
+        self.selected_index: int = 0
+        self._app_ref: Optional[Any] = None
+        self._previous_focus: Optional[Any] = None
+
+    def render(self) -> Text:
+        text = Text()
+        text.append("Select Agent\n", style="bold cyan")
+        text.append("j/k:move  enter:select  q:skip\n\n", style="dim")
+
+        # First option is always "(none) — default Claude"
+        options = ["(none) \u2014 default Claude"] + self._agents
+
+        for i, label in enumerate(options):
+            is_selected = i == self.selected_index
+
+            if is_selected:
+                text.append("> ", style="bold cyan")
+            else:
+                text.append("  ", style="")
+
+            style = "bold" if is_selected else ""
+            text.append(f"{label}\n", style=style)
+
+        return text
+
+    def on_key(self, event: events.Key) -> None:
+        key = event.key
+        total = 1 + len(self._agents)  # (none) + agent names
+
+        if key in ("j", "down"):
+            self.selected_index = (self.selected_index + 1) % total
+            self.refresh()
+            event.stop()
+
+        elif key in ("k", "up"):
+            self.selected_index = (self.selected_index - 1) % total
+            self.refresh()
+            event.stop()
+
+        elif key == "enter":
+            self._select()
+            event.stop()
+
+        elif key in ("escape", "q", "Q"):
+            self._skip()
+            event.stop()
+
+    def _hide(self) -> None:
+        self.remove_class("visible")
+        if self._previous_focus is not None:
+            try:
+                self._previous_focus.focus()
+            except Exception:
+                pass
+        self._previous_focus = None
+
+    def _select(self) -> None:
+        if self.selected_index == 0:
+            # "(none)" selected
+            self.post_message(self.AgentSelected(None))
+        else:
+            agent_name = self._agents[self.selected_index - 1]
+            self.post_message(self.AgentSelected(agent_name))
+        self._hide()
+
+    def _skip(self) -> None:
+        self.post_message(self.AgentSelectSkipped())
+        self._hide()
+
+    def show(self, agents: List[str], app_ref: Optional[Any] = None) -> None:
+        """Display the modal with available agents.
+
+        Args:
+            agents: List of agent names (from scan_agents).
+            app_ref: Reference to the app for focus management.
+        """
+        self._agents = list(agents)
+        self._app_ref = app_ref
+        self._previous_focus = None
+        if app_ref:
+            try:
+                self._previous_focus = app_ref.focused
+            except Exception:
+                pass
+        self.selected_index = 0
+        self.refresh()
+        self.add_class("visible")
+        try:
+            self.focus()
+        except Exception:
+            pass

--- a/src/overcode/tui_widgets/command_bar.py
+++ b/src/overcode/tui_widgets/command_bar.py
@@ -91,6 +91,7 @@ class CommandBar(Static):
     new_agent_name: Optional[str] = None  # Store name between steps
     new_agent_bypass: bool = False  # Store permissions between steps
     new_agent_teams: bool = False  # Store teams flag between steps (#309)
+    new_agent_claude_agent: Optional[str] = None  # Store selected Claude agent between steps
     heartbeat_freq: Optional[int] = None  # Store frequency between heartbeat steps (#171)
     new_remote_sister: Optional[str] = None  # Store selected sister name for remote agent flow (#310)
 
@@ -112,12 +113,13 @@ class CommandBar(Static):
 
     class NewAgentRequested(Message):
         """Message sent when user wants to create a new agent."""
-        def __init__(self, agent_name: str, directory: Optional[str] = None, bypass_permissions: bool = False, agent_teams: bool = False):
+        def __init__(self, agent_name: str, directory: Optional[str] = None, bypass_permissions: bool = False, agent_teams: bool = False, claude_agent: Optional[str] = None):
             super().__init__()
             self.agent_name = agent_name
             self.directory = directory
             self.bypass_permissions = bypass_permissions
             self.agent_teams = agent_teams
+            self.claude_agent = claude_agent
 
     class NewRemoteAgentRequested(Message):
         """Message sent when user wants to launch a remote agent on a sister (#310)."""
@@ -368,6 +370,28 @@ class CommandBar(Static):
             # Use current working directory if none specified
             self.new_agent_dir = str(Path.cwd())
 
+        # Check for available Claude agents
+        from ..agent_scanner import scan_agents
+        agents = scan_agents(self.new_agent_dir)
+
+        if agents:
+            # Show agent selection modal (TUI will handle the message and
+            # transition us to name step afterwards)
+            from .agent_select_modal import AgentSelectModal
+            try:
+                modal = self.app.query_one("#agent-select-modal", AgentSelectModal)
+                modal.show(agents, self.app)
+            except Exception:
+                # Modal not found — fall through to name step
+                self._transition_to_name_step()
+        else:
+            # No agents found — skip straight to name step
+            self._transition_to_name_step()
+
+    def _transition_to_name_step(self) -> None:
+        """Transition to the name input step of new agent creation."""
+        from pathlib import Path
+
         # Derive default agent name from directory basename (#131)
         # If an agent with that name exists, increment (foo -> foo2 -> foo3)
         base_name = Path(self.new_agent_dir).name
@@ -444,12 +468,13 @@ class CommandBar(Static):
 
     def _create_new_agent(self, name: str, bypass_permissions: bool = False, agent_teams: bool = False) -> None:
         """Create a new agent with the given name, directory, permission mode, and teams flag."""
-        self.post_message(self.NewAgentRequested(name, self.new_agent_dir, bypass_permissions, agent_teams))
+        self.post_message(self.NewAgentRequested(name, self.new_agent_dir, bypass_permissions, agent_teams, claude_agent=self.new_agent_claude_agent))
         # Reset state
         self.new_agent_dir = None
         self.new_agent_name = None
         self.new_agent_bypass = False
         self.new_agent_teams = False
+        self.new_agent_claude_agent = None
         self.mode = "send"
         self._update_target_label()
 
@@ -592,6 +617,7 @@ class CommandBar(Static):
         self.new_agent_name = None
         self.new_agent_bypass = False
         self.new_agent_teams = False
+        self.new_agent_claude_agent = None
         self.new_remote_sister = None  # Reset remote agent state (#310)
         self.heartbeat_freq = None  # Reset heartbeat state (#171)
         self._update_target_label()


### PR DESCRIPTION
## Summary
- Scans `.claude/agents/` (project + user level) for Claude agent personas when launching a new agent
- Shows a keyboard-navigable selection modal (j/k/enter/q) if agents are found; skips if none
- Adds `--agent/-a` CLI option to `overcode launch`
- Persists selected agent on the session and passes `--agent <name>` to Claude CLI

## Test plan
- [ ] TUI: press `n`, enter directory with `.claude/agents/` files → modal appears → select → launches with `--agent`
- [ ] TUI: directory without agents → skips modal, goes straight to name step
- [ ] TUI: modal appears → press q/Esc → continues without agent
- [ ] CLI: `overcode launch -n test --agent code-reviewer -d /some/project`
- [ ] `overcode show <name>` displays selected agent
- [ ] `pytest tests/` passes (3102 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)