### PR TITLE
Increase slash command delays for reliable /clear (#307)

### DIFF
--- a/src/overcode/implementations.py
+++ b/src/overcode/implementations.py
@@ -151,6 +151,17 @@ class RealTmux:
                     if rest:
                         pane.send_keys(rest, enter=False)
                         time.sleep(0.1)
+                elif keys.startswith('/') and len(keys) > 1:
+                    # Special handling for slash commands (#307)
+                    # Claude Code shows a command menu when / is typed;
+                    # send / separately so the menu has time to appear
+                    # before the rest of the command and Enter arrive.
+                    pane.send_keys('/', enter=False)
+                    time.sleep(0.3)
+                    rest = keys[1:]
+                    if rest:
+                        pane.send_keys(rest, enter=False)
+                        time.sleep(0.15)
                 else:
                     pane.send_keys(keys, enter=False)
                     # Small delay for Claude Code to process text

--- a/src/overcode/tmux_manager.py
+++ b/src/overcode/tmux_manager.py
@@ -146,6 +146,17 @@ class TmuxManager:
                     if rest:
                         pane.send_keys(rest, enter=False)
                         time.sleep(0.1)
+                elif keys.startswith('/') and len(keys) > 1:
+                    # Special handling for slash commands (#307)
+                    # Claude Code shows a command menu when / is typed;
+                    # send / separately so the menu has time to appear
+                    # before the rest of the command and Enter arrive.
+                    pane.send_keys('/', enter=False)
+                    time.sleep(0.3)
+                    rest = keys[1:]
+                    if rest:
+                        pane.send_keys(rest, enter=False)
+                        time.sleep(0.15)
                 else:
                     pane.send_keys(keys, enter=False)
                     # Small delay for Claude Code to process text

--- a/tests/unit/test_tmux_manager.py
+++ b/tests/unit/test_tmux_manager.py
@@ -847,6 +847,43 @@ class TestTmuxManagerLibtmuxKeys:
         ]
 
 
+    @patch("overcode.tmux_manager.time.sleep")
+    def test_send_keys_slash_command_splits_and_delays(self, mock_sleep):
+        """send_keys with / prefix sends / first with longer delay (#307)."""
+        manager, mock_pane = self._make_manager_with_pane()
+
+        call_order = []
+        mock_pane.send_keys.side_effect = lambda *a, **kw: call_order.append(("send", a, kw))
+        mock_sleep.side_effect = lambda t: call_order.append(("sleep", t))
+
+        manager.send_keys(1, "/clear", enter=True)
+
+        assert call_order == [
+            ("send", ("/",), {"enter": False}),
+            ("sleep", 0.3),
+            ("send", ("clear",), {"enter": False}),
+            ("sleep", 0.15),
+            ("send", ("",), {"enter": True}),
+        ]
+
+    @patch("overcode.tmux_manager.time.sleep")
+    def test_send_keys_slash_only_not_split(self, mock_sleep):
+        """send_keys with just '/' does NOT split (len == 1)."""
+        manager, mock_pane = self._make_manager_with_pane()
+
+        call_order = []
+        mock_pane.send_keys.side_effect = lambda *a, **kw: call_order.append(("send", a, kw))
+        mock_sleep.side_effect = lambda t: call_order.append(("sleep", t))
+
+        manager.send_keys(1, "/", enter=True)
+
+        assert call_order == [
+            ("send", ("/",), {"enter": False}),
+            ("sleep", 0.1),
+            ("send", ("",), {"enter": True}),
+        ]
+
+
 class TestTmuxManagerLibtmuxKillSession:
     """Test kill_session via libtmux."""
 


### PR DESCRIPTION
## Summary
- Claude Code's command menu sometimes takes longer than 150ms to appear after `/` is typed, causing `/clear` to hang
- Increased the post-`/` delay from 0.15s to 0.3s to give the menu time to appear
- Increased the post-text delay from 0.1s to 0.15s for the menu to filter before Enter
- Updated both `tmux_manager.py` and `implementations.py` (the two send_keys paths)
- Added tests for slash command split-and-delay behavior

Closes #307

## Test plan
- [x] All 13 `TestTmuxManagerLibtmuxKeys` tests pass including new slash command tests
- [ ] Manual test: `/clear` reliably executes on first try

🤖 Generated with [Claude Code](https://claude.com/claude-code)