### PR TITLE
Prevent focus stealing during instruction input (#321)

### DIFF
--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -733,7 +733,8 @@ class SupervisorTUI(
         """Check if focus recovery should run.
 
         Returns False when an overlay is visible (fullscreen preview, help,
-        any modal) or focus is already on a session/input widget.
+        any modal), the command bar is open, or focus is already on a
+        session/input widget.
         """
         # Don't steal focus from overlays
         try:
@@ -750,6 +751,13 @@ class SupervisorTUI(
             pass
         if self._any_modal_visible():
             return False
+        # Don't steal focus from command bar during instruction input (#321)
+        try:
+            cmd_bar = self.query_one("#command-bar")
+            if cmd_bar.has_class("visible"):
+                return False
+        except NoMatches:
+            pass
         # Only recover if focus is not on a session or input widget
         if self.focused is None:
             return True


### PR DESCRIPTION
## Summary
- The `on_key()` focus recovery handler ran on every keystroke, even while the command bar was open for instruction input
- During rapid typing/dictation, `self.focused` could momentarily report a non-Input widget, causing focus to be stolen from the command bar to a SessionSummary widget
- The instruction text appeared typed but Enter never reached the command bar, so the message was dropped
- Added a command bar visibility check in `_should_recover_focus()` to skip focus recovery entirely when the command bar is open

Closes #321

## Test plan
- [x] Full `test_tui.py` suite passes (190/190, 10 skipped)
- [ ] Manual test: open command bar with `i`, dictate long text, verify it sends

🤖 Generated with [Claude Code](https://claude.com/claude-code)