### PR TITLE
Fix false duplicate daemon detection caused by zombie processes

### DIFF
--- a/src/overcode/daemon_utils.py
+++ b/src/overcode/daemon_utils.py
@@ -78,12 +78,29 @@ def create_daemon_helpers(
             os.kill(pid, signal.SIGTERM)
             # Wait for process to actually terminate before removing PID file
             start = time.time()
+            terminated = False
             while time.time() - start < 5.0:
                 try:
                     os.kill(pid, 0)
                     time.sleep(0.1)
                 except (OSError, ProcessLookupError):
+                    terminated = True
                     break
+
+            if not terminated:
+                # Still alive after timeout — force kill
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                    time.sleep(0.1)
+                except (OSError, ProcessLookupError):
+                    pass
+
+            # Reap zombie if we're the parent process
+            try:
+                os.waitpid(pid, os.WNOHANG)
+            except ChildProcessError:
+                pass  # Not our child, or already reaped
+
             remove_pid_file(pid_path)
             return True
         except (OSError, ProcessLookupError):

--- a/src/overcode/pid_utils.py
+++ b/src/overcode/pid_utils.py
@@ -11,8 +11,10 @@ daemons try to start simultaneously.
 import fcntl
 import os
 import signal
+import subprocess
+import threading
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 
 def is_process_running(pid_file: Path) -> bool:
@@ -162,6 +164,66 @@ def acquire_daemon_lock(pid_file: Path) -> Tuple[bool, Optional[int]]:
 # Module-level variable to hold the lock file descriptor.
 # This prevents garbage collection from closing the fd and releasing the lock.
 _held_lock_fd: Optional[int] = None
+
+
+def is_daemon_lock_held(pid_file: Path) -> bool:
+    """Check if a daemon lock is currently held (i.e., daemon is actively running).
+
+    Probes the fcntl lock file that the daemon holds for its entire lifetime.
+    More reliable than pgrep: immune to zombie processes, PID reuse, and
+    substring false matches.
+
+    Args:
+        pid_file: Path to the daemon's PID file (lock file is .lock suffix)
+
+    Returns:
+        True if the lock is held (daemon is running), False otherwise.
+    """
+    lock_file = pid_file.with_suffix('.lock')
+    if not lock_file.exists():
+        return False
+    try:
+        fd = os.open(str(lock_file), os.O_RDONLY)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            # We got the lock — no daemon holds it
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            return False
+        except OSError:
+            # Lock is held by another process = daemon is running
+            return True
+        finally:
+            os.close(fd)
+    except OSError:
+        return False
+
+
+def spawn_daemon(args: List[str]) -> Optional[int]:
+    """Spawn a daemon process without leaving zombies.
+
+    Uses start_new_session=True so the child survives parent exit,
+    and a background reaper thread to prevent zombie accumulation.
+
+    Args:
+        args: Command arguments (e.g., [sys.executable, "-m", "overcode.monitor_daemon", ...])
+
+    Returns:
+        The daemon's PID, or None if spawn failed.
+    """
+    try:
+        proc = subprocess.Popen(
+            args,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        # Reaper thread prevents zombie when daemon exits while parent is alive
+        threading.Thread(
+            target=proc.wait, daemon=True, name=f"reap-{proc.pid}"
+        ).start()
+        return proc.pid
+    except (OSError, subprocess.SubprocessError):
+        return None
 
 
 def count_daemon_processes(pattern: str = "monitor_daemon", session: str = None) -> int:

--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -11,7 +11,6 @@ TODO: Split this file into smaller modules for maintainability:
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from typing import List, Optional
-import subprocess
 import sys
 import time
 
@@ -34,7 +33,7 @@ from .monitor_daemon_state import get_monitor_daemon_state
 from .monitor_daemon import (
     is_monitor_daemon_running,
 )
-from .pid_utils import count_daemon_processes
+from .pid_utils import is_daemon_lock_held, spawn_daemon
 from .summarizer_component import (
     SummarizerComponent,
     SummarizerConfig,
@@ -281,8 +280,6 @@ class SupervisorTUI(
         # Flags to prevent overlapping async updates (fast and slow paths are independent)
         self._status_update_in_progress = False
         self._stats_update_in_progress = False
-        # Track if we've warned about multiple daemons (to avoid spam)
-        self._multiple_daemon_warning_shown = False
         # Track whether sessions have been loaded at least once (for startup sequencing)
         self._initial_sessions_loaded = False
         # Track attention jump state (for 'b' key cycling)
@@ -490,7 +487,8 @@ class SupervisorTUI(
         # All I/O happens here in the worker thread
         self._usage_monitor.fetch()  # Internally throttled to 90s
         monitor_state = get_monitor_daemon_state(self.tmux_session)
-        daemon_count = count_daemon_processes("monitor_daemon", session=self.tmux_session)
+        from .settings import get_monitor_daemon_pid_path
+        daemon_lock_held = is_daemon_lock_held(get_monitor_daemon_pid_path(self.tmux_session))
 
         # Gather data that DaemonStatusBar.update_status() would fetch
         asleep_ids = set()
@@ -520,14 +518,14 @@ class SupervisorTUI(
 
         # Apply results on main thread
         self.call_from_thread(
-            self._apply_daemon_status, daemon_bar, monitor_state, daemon_count, asleep_ids
+            self._apply_daemon_status, daemon_bar, monitor_state, daemon_lock_held, asleep_ids
         )
 
     def _apply_daemon_status(
         self,
         daemon_bar: "DaemonStatusBar",
         monitor_state,
-        daemon_count: int,
+        daemon_lock_held: bool,
         asleep_ids: set,
     ) -> None:
         """Apply daemon status results on main thread (no I/O)."""
@@ -537,19 +535,6 @@ class SupervisorTUI(
         daemon_bar._usage_snapshot = self._usage_monitor.snapshot
         daemon_bar.refresh()
         self._mark_event("apply_daemon_end")
-
-        # Check for multiple daemon processes (potential time tracking bug)
-        if daemon_count > 1 and not self._multiple_daemon_warning_shown:
-            self._multiple_daemon_warning_shown = True
-            self.notify(
-                f"WARNING: {daemon_count} monitor daemons detected! "
-                "This causes time tracking bugs. Press \\ to restart daemon.",
-                severity="error",
-                timeout=30
-            )
-        elif daemon_count <= 1:
-            # Reset warning flag when back to normal
-            self._multiple_daemon_warning_shown = False
 
     def update_timeline(self) -> None:
         """Update the status timeline widget (kicks off background worker)"""
@@ -2094,27 +2079,23 @@ class SupervisorTUI(
         The Monitor Daemon handles status tracking, time accumulation,
         stats sync, and user presence detection.
         """
-        # Check PID file first
-        if is_monitor_daemon_running(self.tmux_session):
+        # Check lock file first (authoritative: daemon holds flock for its lifetime)
+        from .settings import get_monitor_daemon_pid_path
+        if is_daemon_lock_held(get_monitor_daemon_pid_path(self.tmux_session)):
             return  # Already running
 
-        # Also check for running processes (in case PID file is stale or daemon is starting)
-        # This prevents race conditions where multiple TUIs start daemons simultaneously
-        daemon_count = count_daemon_processes("monitor_daemon", session=self.tmux_session)
-        if daemon_count > 0:
-            return  # Daemon process exists, just PID file might be missing/stale
+        # Fallback: PID file check (covers startup window before lock is acquired)
+        if is_monitor_daemon_running(self.tmux_session):
+            return
 
-        try:
-            subprocess.Popen(
-                [sys.executable, "-m", "overcode.monitor_daemon",
-                 "--session", self.tmux_session],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                start_new_session=True,
-            )
+        pid = spawn_daemon([
+            sys.executable, "-m", "overcode.monitor_daemon",
+            "--session", self.tmux_session,
+        ])
+        if pid:
             self.notify("Monitor Daemon started", severity="information")
-        except (OSError, subprocess.SubprocessError) as e:
-            self.notify(f"Failed to start Monitor Daemon: {e}", severity="warning")
+        else:
+            self.notify("Failed to start Monitor Daemon", severity="warning")
 
     def _execute_kill(self, focused: "SessionSummary", session_name: str, session_id: str) -> None:
         """Execute the actual kill operation after confirmation."""

--- a/src/overcode/tui_actions/daemon.py
+++ b/src/overcode/tui_actions/daemon.py
@@ -4,7 +4,6 @@ Daemon action methods for TUI.
 Handles Monitor Daemon, Supervisor Daemon, and Web Server controls.
 """
 
-import subprocess
 import sys
 from typing import TYPE_CHECKING
 
@@ -64,18 +63,16 @@ class DaemonActionsMixin:
         except NoMatches:
             pass
 
-        try:
-            subprocess.Popen(
-                [sys.executable, "-m", "overcode.supervisor_daemon",
-                 "--session", self.tmux_session],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                start_new_session=True,
-            )
+        from ..pid_utils import spawn_daemon
+        pid = spawn_daemon([
+            sys.executable, "-m", "overcode.supervisor_daemon",
+            "--session", self.tmux_session,
+        ])
+        if pid:
             self.notify("Started Supervisor Daemon", severity="information")
             self.set_timer(1.0, self.update_daemon_status)
-        except (OSError, subprocess.SubprocessError) as e:
-            self.notify(f"Failed to start Supervisor Daemon: {e}", severity="error")
+        else:
+            self.notify("Failed to start Supervisor Daemon", severity="error")
 
     def action_supervisor_stop(self) -> None:
         """Stop the Supervisor Daemon (requires double-press confirmation)."""
@@ -170,17 +167,14 @@ class DaemonActionsMixin:
 
     def _start_monitor_daemon(self) -> None:
         """Start the monitor daemon (called by action_monitor_restart)."""
+        from ..pid_utils import spawn_daemon
         from ..tui_widgets import DaemonPanel
 
-        try:
-            subprocess.Popen(
-                [sys.executable, "-m", "overcode.monitor_daemon",
-                 "--session", self.tmux_session],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                start_new_session=True,
-            )
-
+        pid = spawn_daemon([
+            sys.executable, "-m", "overcode.monitor_daemon",
+            "--session", self.tmux_session,
+        ])
+        if pid:
             self.notify("Monitor Daemon restarted", severity="information")
             try:
                 panel = self.query_one("#daemon-panel", DaemonPanel)
@@ -188,8 +182,8 @@ class DaemonActionsMixin:
             except NoMatches:
                 pass
             self.set_timer(1.0, self.update_daemon_status)
-        except (OSError, subprocess.SubprocessError) as e:
-            self.notify(f"Failed to restart Monitor Daemon: {e}", severity="error")
+        else:
+            self.notify("Failed to restart Monitor Daemon", severity="error")
 
     def action_toggle_web_server(self) -> None:
         """Toggle the web analytics dashboard server on/off."""

--- a/tests/unit/test_tui_actions_daemon.py
+++ b/tests/unit/test_tui_actions_daemon.py
@@ -110,12 +110,12 @@ class TestSupervisorStart:
         mock_tui._ensure_monitor_daemon.assert_called_once()
         mock_sleep.assert_called_once_with(1.0)
 
-    @patch("overcode.tui_actions.daemon.subprocess")
+    @patch("overcode.pid_utils.spawn_daemon", return_value=12345)
     @patch("overcode.tui_actions.daemon.sys")
     @patch("overcode.supervisor_daemon.is_supervisor_daemon_running", return_value=False)
     @patch("overcode.monitor_daemon.is_monitor_daemon_running", return_value=True)
-    def test_successful_start_calls_popen(self, mock_monitor_running, mock_supervisor_running, mock_sys, mock_subprocess):
-        """Should call Popen to start supervisor daemon."""
+    def test_successful_start_calls_spawn_daemon(self, mock_monitor_running, mock_supervisor_running, mock_sys, mock_spawn):
+        """Should call spawn_daemon to start supervisor daemon."""
         from overcode.tui_actions.daemon import DaemonActionsMixin
 
         mock_tui = MagicMock()
@@ -125,20 +125,19 @@ class TestSupervisorStart:
 
         DaemonActionsMixin._do_supervisor_start(mock_tui)
 
-        mock_subprocess.Popen.assert_called_once()
-        call_args = mock_subprocess.Popen.call_args
-        assert call_args[0][0] == ["/usr/bin/python3", "-m", "overcode.supervisor_daemon", "--session", "test"]
-        assert call_args[1]["start_new_session"] is True
+        mock_spawn.assert_called_once()
+        call_args = mock_spawn.call_args[0][0]
+        assert call_args == ["/usr/bin/python3", "-m", "overcode.supervisor_daemon", "--session", "test"]
         mock_tui.notify.assert_called_once()
         assert "Started" in mock_tui.notify.call_args[0][0]
         assert mock_tui.notify.call_args[1]["severity"] == "information"
         mock_tui.set_timer.assert_called_once_with(1.0, mock_tui.update_daemon_status)
 
-    @patch("overcode.tui_actions.daemon.subprocess")
+    @patch("overcode.pid_utils.spawn_daemon", return_value=12345)
     @patch("overcode.tui_actions.daemon.sys")
     @patch("overcode.supervisor_daemon.is_supervisor_daemon_running", return_value=False)
     @patch("overcode.monitor_daemon.is_monitor_daemon_running", return_value=True)
-    def test_start_logs_to_daemon_panel(self, mock_monitor_running, mock_supervisor_running, mock_sys, mock_subprocess):
+    def test_start_logs_to_daemon_panel(self, mock_monitor_running, mock_supervisor_running, mock_sys, mock_spawn):
         """Should log startup message to daemon panel."""
         from overcode.tui_actions.daemon import DaemonActionsMixin
 
@@ -153,11 +152,11 @@ class TestSupervisorStart:
 
         assert any("Starting Supervisor Daemon" in line for line in mock_panel.log_lines)
 
-    @patch("overcode.tui_actions.daemon.subprocess.Popen", side_effect=OSError("No such file"))
+    @patch("overcode.pid_utils.spawn_daemon", return_value=None)
     @patch("overcode.supervisor_daemon.is_supervisor_daemon_running", return_value=False)
     @patch("overcode.monitor_daemon.is_monitor_daemon_running", return_value=True)
-    def test_start_handles_oserror(self, mock_monitor_running, mock_supervisor_running, mock_popen):
-        """Should notify error when Popen raises OSError."""
+    def test_start_handles_spawn_failure(self, mock_monitor_running, mock_supervisor_running, mock_spawn):
+        """Should notify error when spawn_daemon fails."""
         from overcode.tui_actions.daemon import DaemonActionsMixin
 
         mock_tui = MagicMock()
@@ -169,11 +168,11 @@ class TestSupervisorStart:
         assert "Failed" in mock_tui.notify.call_args[0][0]
         assert mock_tui.notify.call_args[1]["severity"] == "error"
 
-    @patch("overcode.tui_actions.daemon.subprocess")
+    @patch("overcode.pid_utils.spawn_daemon", return_value=12345)
     @patch("overcode.tui_actions.daemon.sys")
     @patch("overcode.supervisor_daemon.is_supervisor_daemon_running", return_value=False)
     @patch("overcode.monitor_daemon.is_monitor_daemon_running", return_value=True)
-    def test_start_handles_missing_panel(self, mock_monitor_running, mock_supervisor_running, mock_sys, mock_subprocess):
+    def test_start_handles_missing_panel(self, mock_monitor_running, mock_supervisor_running, mock_sys, mock_spawn):
         """Should not crash when daemon panel is not mounted."""
         from overcode.tui_actions.daemon import DaemonActionsMixin
         from textual.css.query import NoMatches
@@ -185,7 +184,7 @@ class TestSupervisorStart:
         # Should not raise
         DaemonActionsMixin._do_supervisor_start(mock_tui)
 
-        mock_subprocess.Popen.assert_called_once()
+        mock_spawn.assert_called_once()
 
 
 class TestSupervisorStop:
@@ -473,10 +472,10 @@ class TestMonitorRestart:
 class TestStartMonitorDaemon:
     """Test _start_monitor_daemon method."""
 
-    @patch("overcode.tui_actions.daemon.subprocess")
+    @patch("overcode.pid_utils.spawn_daemon", return_value=12345)
     @patch("overcode.tui_actions.daemon.sys")
-    def test_successful_start(self, mock_sys, mock_subprocess):
-        """Should call Popen to start monitor daemon."""
+    def test_successful_start(self, mock_sys, mock_spawn):
+        """Should call spawn_daemon to start monitor daemon."""
         from overcode.tui_actions.daemon import DaemonActionsMixin
 
         mock_sys.executable = "/usr/bin/python3"
@@ -490,19 +489,18 @@ class TestStartMonitorDaemon:
 
         DaemonActionsMixin._start_monitor_daemon(mock_tui)
 
-        mock_subprocess.Popen.assert_called_once()
-        call_args = mock_subprocess.Popen.call_args
-        assert call_args[0][0] == ["/usr/bin/python3", "-m", "overcode.monitor_daemon", "--session", "test"]
-        assert call_args[1]["start_new_session"] is True
+        mock_spawn.assert_called_once()
+        call_args = mock_spawn.call_args[0][0]
+        assert call_args == ["/usr/bin/python3", "-m", "overcode.monitor_daemon", "--session", "test"]
         mock_tui.notify.assert_called_once()
         assert "restarted" in mock_tui.notify.call_args[0][0]
         assert mock_tui.notify.call_args[1]["severity"] == "information"
         assert any("restarted" in line for line in mock_panel.log_lines)
         mock_tui.set_timer.assert_called_once_with(1.0, mock_tui.update_daemon_status)
 
-    @patch("overcode.tui_actions.daemon.subprocess.Popen", side_effect=OSError("Command not found"))
-    def test_oserror(self, mock_popen):
-        """Should notify error when Popen raises OSError."""
+    @patch("overcode.pid_utils.spawn_daemon", return_value=None)
+    def test_spawn_failure(self, mock_spawn):
+        """Should notify error when spawn_daemon fails."""
         from overcode.tui_actions.daemon import DaemonActionsMixin
 
         mock_tui = MagicMock()
@@ -516,9 +514,9 @@ class TestStartMonitorDaemon:
         # Should NOT set timer on failure
         mock_tui.set_timer.assert_not_called()
 
-    @patch("overcode.tui_actions.daemon.subprocess")
+    @patch("overcode.pid_utils.spawn_daemon", return_value=12345)
     @patch("overcode.tui_actions.daemon.sys")
-    def test_start_handles_missing_panel(self, mock_sys, mock_subprocess):
+    def test_start_handles_missing_panel(self, mock_sys, mock_spawn):
         """Should not crash when daemon panel is not mounted."""
         from overcode.tui_actions.daemon import DaemonActionsMixin
         from textual.css.query import NoMatches
@@ -530,7 +528,7 @@ class TestStartMonitorDaemon:
         # Should not raise
         DaemonActionsMixin._start_monitor_daemon(mock_tui)
 
-        mock_subprocess.Popen.assert_called_once()
+        mock_spawn.assert_called_once()
         mock_tui.notify.assert_called_once()
         assert "restarted" in mock_tui.notify.call_args[0][0]
 


### PR DESCRIPTION
## Summary
- Replaces unreliable `pgrep -f` based daemon counting with `fcntl` lock probing via new `is_daemon_lock_held()` — the lock the daemon holds for its entire lifetime is the authoritative source of truth, immune to zombie processes, PID reuse, and substring false matches
- Adds `spawn_daemon()` helper with a background reaper thread to prevent zombie accumulation when daemon processes exit while the TUI is still running
- Hardens `daemon_utils.stop()` with SIGKILL fallback after timeout and `os.waitpid()` zombie reaping

## Root cause
Daemon processes launched via `subprocess.Popen()` had their Popen object discarded immediately. When a daemon exited (e.g., during restart via `\`), it became a zombie — still visible to `pgrep` and `os.kill(pid, 0)`. The TUI's pgrep-based duplicate detection then counted both the zombie and the new daemon, triggering false "WARNING: N monitor daemons detected!" warnings.

## Test plan
- [x] All 74 affected unit tests pass (test_pid_utils, test_tui_actions_daemon, test_daemon_utils)
- [x] Full unit test suite passes
- [ ] Manual: restart daemon via `\` key, verify no duplicate warning appears
- [ ] Manual: verify daemon auto-starts on TUI mount

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)