### PR TITLE
Fix preview pane scroll position when switching agents

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overcode"
-version = "0.2.5"
+version = "0.2.6"
 description = "A supervisor for managing multiple Claude Code instances in tmux"
 authors = [
     {name = "Mike Bond"}

--- a/src/overcode/tui_widgets/preview_pane.py
+++ b/src/overcode/tui_widgets/preview_pane.py
@@ -63,8 +63,14 @@ class PreviewPane(ScrollableContainer):
 
     def update_from_widget(self, widget: "SessionSummary") -> None:
         """Update preview content from a SessionSummary widget."""
+        session_changed = widget.session.name != self.session_name
         self.session_name = widget.session.name
         self.content_lines = list(widget.pane_content) if widget.pane_content else []
+
+        # When switching to a different session, always scroll to bottom
+        if session_changed:
+            self._auto_scroll = True
+            self._user_scrolled = False
 
         # Save scroll position before content replacement
         saved_scroll = self.scroll_offset.y


### PR DESCRIPTION
## Summary
- Fixes #350 — preview pane sometimes showed the top of the scroll buffer when switching between agents
- Root cause: `_auto_scroll` was a global flag on the PreviewPane, not per-session. Scrolling up on one agent disabled auto-scroll for all subsequent agent switches
- Fix: reset `_auto_scroll` and `_user_scrolled` when the session name changes, so switching agents always scrolls to bottom

## Test plan
- [x] All 3125 unit tests pass
- [ ] Manual: switch between agents in list+preview mode, verify preview always shows bottom of output
- [ ] Manual: scroll up on one agent's preview, switch to another, verify new agent shows bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)