### PR TITLE
Add per-agent API provider selection (web/bedrock)

### DIFF
--- a/src/overcode/cli/agent.py
+++ b/src/overcode/cli/agent.py
@@ -212,6 +212,10 @@ def launch(
         bool,
         typer.Option("--teams", help="Enable Claude Code agent teams (CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS)"),
     ] = False,
+    provider: Annotated[
+        Optional[str],
+        typer.Option("--provider", "-P", help="API provider: 'web' (Claude.ai OAuth) or 'bedrock' (AWS Bedrock)"),
+    ] = None,
     sister: Annotated[
         Optional[str],
         typer.Option("--sister", "-S", help="Launch on a remote sister machine (by name from config)"),
@@ -270,6 +274,15 @@ def launch(
     # Parse oversight policy
     oversight_policy, oversight_timeout_seconds = _parse_oversight_policy(on_stuck, oversight_timeout)
 
+    # Resolve provider: CLI flag > config default > "web"
+    resolved_provider = provider
+    if resolved_provider is None:
+        from ..config import get_new_agent_defaults
+        resolved_provider = get_new_agent_defaults().get("provider", "web")
+    if resolved_provider not in ("web", "bedrock"):
+        rprint(f"[red]Error: Invalid provider '{resolved_provider}'. Use: web, bedrock[/red]")
+        raise typer.Exit(code=1)
+
     # Default to current directory if not specified
     working_dir = directory if directory else os.getcwd()
 
@@ -288,6 +301,7 @@ def launch(
         budget_usd=budget,
         claude_agent=agent,
         model=model,
+        provider=resolved_provider,
     )
 
     if result:
@@ -304,6 +318,8 @@ def launch(
             rprint(f"  Agent: {agent}")
         if teams:
             rprint("  Agent teams: enabled")
+        if resolved_provider != "web":
+            rprint(f"  Provider: {resolved_provider}")
         if budget is not None and budget > 0:
             rprint(f"  Budget: ${budget:.2f}")
 
@@ -479,6 +495,8 @@ def list_agents(
 
     # Pre-compute: any agent with budget, column alignment widths
     any_has_budget = any(s.cost_budget_usd > 0 for s in sessions)
+    any_has_provider = any(getattr(s, 'provider', 'web') not in ('web', None, '') for s in sessions)
+    any_has_model = any(getattr(s, 'model', None) for s in sessions)
     max_name_len = max((len(s.name) for s in sessions), default=10)
     name_width = min(max(max_name_len, 10), 20)
     max_repo_width = max((len(s.repo_name or "n/a") for s in sessions), default=5)
@@ -585,6 +603,8 @@ def list_agents(
             oversight_deadline=oversight_deadline,
             pr_number=getattr(sess, 'pr_number', None),
             any_has_pr=any_has_pr,
+            any_has_model=any_has_model,
+            any_has_provider=any_has_provider,
             monochrome=False,
             summary_detail=detail,
             has_sisters=has_sisters,

--- a/src/overcode/config.py
+++ b/src/overcode/config.py
@@ -340,6 +340,7 @@ def get_new_agent_defaults() -> dict:
     return {
         "bypass_permissions": bool(defaults.get("bypass_permissions", False)),
         "agent_teams": bool(defaults.get("agent_teams", False)),
+        "provider": defaults.get("provider", "web"),
     }
 
 
@@ -352,6 +353,22 @@ def save_new_agent_defaults(defaults: dict) -> None:
     config = load_config()
     config["new_agent_defaults"] = defaults
     save_config(config)
+
+
+def get_bedrock_config() -> dict:
+    """Get AWS Bedrock configuration.
+
+    Config format in ~/.overcode/config.yaml:
+        bedrock:
+          region: us-east-1
+
+    Returns:
+        Dict with region (str).
+    """
+    bedrock = _get_config_value("bedrock", {})
+    return {
+        "region": bedrock.get("region", "us-east-1"),
+    }
 
 
 def get_jobs_retention_hours() -> float:

--- a/src/overcode/launcher.py
+++ b/src/overcode/launcher.py
@@ -141,6 +141,7 @@ class ClaudeLauncher:
         agent_teams: bool = False,
         claude_agent: Optional[str] = None,
         model: Optional[str] = None,
+        provider: str = "web",
     ) -> dict:
         """Build the kwargs dict for SessionManager.create_session.
 
@@ -160,6 +161,7 @@ class ClaudeLauncher:
             agent_teams=agent_teams,
             claude_agent=claude_agent,
             model=model,
+            provider=provider,
             session_id=session_id,
         )
 
@@ -187,6 +189,13 @@ class ClaudeLauncher:
 
         if metadata.get('agent_teams'):
             env_prefix += " CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1"
+
+        if metadata.get('provider') == 'bedrock':
+            env_prefix += " CLAUDE_CODE_USE_BEDROCK=1"
+            # Use configured region or default to us-east-1
+            from .config import get_bedrock_config
+            bedrock_cfg = get_bedrock_config()
+            env_prefix += f" AWS_REGION={bedrock_cfg['region']}"
 
         mock_scenario = os.environ.get("MOCK_SCENARIO")
         if mock_scenario:
@@ -221,6 +230,7 @@ class ClaudeLauncher:
         budget_usd: Optional[float] = None,
         claude_agent: Optional[str] = None,
         model: Optional[str] = None,
+        provider: str = "web",
     ) -> Optional[Session]:
         """
         Launch an interactive Claude Code session in a tmux window.
@@ -236,6 +246,7 @@ class ClaudeLauncher:
                 If not set, auto-detects from OVERCODE_SESSION_NAME env var.
             allowed_tools: Comma-separated tool list for --allowedTools
             extra_claude_args: Extra Claude CLI flags (each a space-separated string)
+            provider: API provider — "web" (Claude.ai OAuth) or "bedrock" (AWS Bedrock)
 
         Returns:
             Session object if successful, None otherwise
@@ -329,7 +340,7 @@ class ClaudeLauncher:
             standing_instructions=default_instructions,
             permissiveness_mode=perm_mode, allowed_tools=allowed_tools,
             extra_claude_args=extra_claude_args, agent_teams=agent_teams,
-            claude_agent=claude_agent, model=model,
+            claude_agent=claude_agent, model=model, provider=provider,
         )
 
         session = self._prepare_and_launch(

--- a/src/overcode/session_manager.py
+++ b/src/overcode/session_manager.py
@@ -139,6 +139,7 @@ class Session:
     agent_teams: bool = False  # Claude Code agent teams mode (#309)
     claude_agent: Optional[str] = None  # Claude agent persona (from .claude/agents/)
     model: Optional[str] = None  # Claude model (e.g. "sonnet", "opus", "haiku", or full name)
+    provider: str = "web"  # API provider: "web" (Claude.ai OAuth) or "bedrock" (AWS Bedrock)
 
     # Agent hierarchy (#244) - parent/child relationships
     parent_session_id: Optional[str] = None  # ID of parent agent (None = root)
@@ -505,6 +506,7 @@ class SessionManager:
                       agent_teams: bool = False,
                       claude_agent: Optional[str] = None,
                       model: Optional[str] = None,
+                      provider: str = "web",
                       session_id: Optional[str] = None) -> Session:
         """Create and register a new session.
 
@@ -542,6 +544,7 @@ class SessionManager:
             agent_teams=agent_teams,
             claude_agent=claude_agent,
             model=model,
+            provider=provider,
         )
 
         with self._locked_state() as state:

--- a/src/overcode/summary_columns.py
+++ b/src/overcode/summary_columns.py
@@ -182,6 +182,9 @@ class ColumnContext:
     model: str = ""  # Claude model short name or full name
     any_has_model: bool = False  # True if any agent has a model set
 
+    # Provider
+    any_has_provider: bool = False  # True if any agent uses non-web provider
+
     # Sister integration (#245)
     source_host: str = ""
     is_remote: bool = False
@@ -872,6 +875,21 @@ def render_orders_plain(ctx: ColumnContext) -> Optional[str]:
 render_value_plain = _make_simple_render_plain("session.agent_value", str)
 
 
+def render_provider(ctx: ColumnContext) -> ColumnOutput:
+    """API provider emoji: 🌐 web, ☁️ bedrock. Hidden when all agents use web."""
+    provider = getattr(ctx.session, 'provider', 'web') or 'web'
+    if provider == 'bedrock':
+        return [(f" {ctx.e('☁️')}", ctx.mono(f"bold cyan{ctx.bg}", "bold"))]
+    return [(f" {ctx.e('🌐')}", ctx.mono(f"dim{ctx.bg}", "dim"))]
+
+
+def render_provider_plain(ctx: ColumnContext) -> Optional[str]:
+    if not ctx.any_has_provider:
+        return None
+    provider = getattr(ctx.session, 'provider', 'web') or 'web'
+    return provider
+
+
 def render_host(ctx: ColumnContext) -> ColumnOutput:
     """Render host column — hidden when no sisters are configured."""
     if not ctx.has_sisters:
@@ -960,6 +978,10 @@ SUMMARY_COLUMNS: List[SummaryColumn] = [
                   label="Model", render_plain=render_model_plain,
                   visible=lambda ctx: ctx.any_has_model,
                   placeholder_width=6, header="MDL", name="Model"),
+    SummaryColumn(id="provider", group="context", detail_levels=ALL, render=render_provider,
+                  label="Provider", render_plain=render_provider_plain,
+                  visible=lambda ctx: ctx.any_has_provider,
+                  placeholder_width=3, header="PRV", name="Provider"),
 
     # Performance group
     SummaryColumn(id="median_work_time", group="performance", detail_levels=MED_PLUS, render=render_median_work_time,
@@ -1021,6 +1043,7 @@ def build_cli_context(
     any_has_oversight_timeout: bool = False, oversight_deadline: Optional[str] = None,
     pr_number: Optional[int] = None, any_has_pr: bool = False,
     any_has_model: bool = False,
+    any_has_provider: bool = False,
     monochrome: bool = True, emoji_free: bool = False, summary_detail: str = "full",
     has_sisters: bool = False, local_hostname: str = "",
     max_name_width: int = 16, max_repo_width: int = 10,
@@ -1094,6 +1117,7 @@ def build_cli_context(
         any_has_pr=any_has_pr,
         model=getattr(session, 'model', '') or getattr(getattr(session, 'stats', None), 'model', '') or '',
         any_has_model=any_has_model,
+        any_has_provider=any_has_provider,
         source_host=getattr(session, 'source_host', ''),
         is_remote=getattr(session, 'is_remote', False),
         has_sisters=has_sisters,

--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -1645,6 +1645,12 @@ class SupervisorTUI(
             for s in self.sessions
         )
 
+        # Check if any agent uses a non-web provider
+        any_has_provider = any(
+            getattr(s, 'provider', 'web') not in ('web', None, '')
+            for s in self.sessions
+        )
+
         # Check if any agent is busy_sleeping (#289)
         any_is_sleeping = any(
             getattr(w, 'detected_status', '') == "busy_sleeping"
@@ -1706,6 +1712,7 @@ class SupervisorTUI(
                     widget.any_is_sleeping = any_is_sleeping
                     widget.any_has_pr = any_has_pr
                     widget.any_has_model = any_has_model
+                    widget.any_has_provider = any_has_provider
                     widget.oversight_deadline = getattr(new_session, 'oversight_deadline', None)
                     widget.subtree_cost_usd = subtree_costs.get(widget.session.id, 0.0)
                     widget.any_has_subtree_cost = any_has_subtree_cost
@@ -1760,6 +1767,7 @@ class SupervisorTUI(
                 widget.any_is_sleeping = any_is_sleeping
                 widget.any_has_pr = any_has_pr
                 widget.any_has_model = any_has_model
+                widget.any_has_provider = any_has_provider
                 widget.oversight_deadline = getattr(session, 'oversight_deadline', None)
                 widget.subtree_cost_usd = subtree_costs.get(session.id, 0.0)
                 widget.any_has_subtree_cost = any_has_subtree_cost
@@ -2785,11 +2793,13 @@ class SupervisorTUI(
                 dangerously_skip_permissions=bypass_permissions,
                 agent_teams=message.agent_teams,
                 claude_agent=message.claude_agent,
+                provider=getattr(message, 'provider', 'web') or 'web',
             )
             dir_info = f" in {directory}" if directory else ""
             perm_info = " (bypass mode)" if bypass_permissions else ""
             agent_info = f" (agent: {message.claude_agent})" if message.claude_agent else ""
-            self.notify(f"Created agent: {agent_name}{dir_info}{perm_info}{agent_info}", severity="information")
+            provider_info = f" (bedrock)" if getattr(message, 'provider', 'web') == 'bedrock' else ""
+            self.notify(f"Created agent: {agent_name}{dir_info}{perm_info}{agent_info}{provider_info}", severity="information")
             # Refresh to show new agent
             self.refresh_sessions()
         except Exception as e:

--- a/src/overcode/tui_widgets/command_bar.py
+++ b/src/overcode/tui_widgets/command_bar.py
@@ -34,6 +34,8 @@ def get_mode_label_and_placeholder(mode: str, target_session: Optional[str]) -> 
         return "[New Agent: Permissions] ", "Type 'bypass' for --dangerously-skip-permissions, or Enter for normal..."
     elif mode == "new_agent_teams":
         return "[New Agent: Teams] ", "Type 'yes' to enable agent teams, or Enter to skip..."
+    elif mode == "new_agent_provider":
+        return "[New Agent: Provider] ", "Type 'bedrock' for AWS Bedrock, or Enter for web (Claude.ai)..."
     elif mode == "new_remote_agent_sister":
         return "[Remote Agent: Sister] ", "Enter sister name..."
     elif mode == "new_remote_agent_dir":
@@ -116,13 +118,14 @@ class CommandBar(Static):
 
     class NewAgentRequested(Message):
         """Message sent when user wants to create a new agent."""
-        def __init__(self, agent_name: str, directory: Optional[str] = None, bypass_permissions: bool = False, agent_teams: bool = False, claude_agent: Optional[str] = None):
+        def __init__(self, agent_name: str, directory: Optional[str] = None, bypass_permissions: bool = False, agent_teams: bool = False, claude_agent: Optional[str] = None, provider: str = "web"):
             super().__init__()
             self.agent_name = agent_name
             self.directory = directory
             self.bypass_permissions = bypass_permissions
             self.agent_teams = agent_teams
             self.claude_agent = claude_agent
+            self.provider = provider
 
     class NewRemoteAgentRequested(Message):
         """Message sent when user wants to launch a remote agent on a sister (#310)."""
@@ -310,9 +313,19 @@ class CommandBar(Static):
                 event.input.value = ""
                 return
             elif self.mode == "new_agent_teams":
-                # Step 4: Teams chosen, create agent
-                teams = text.lower().strip() in ("yes", "y", "true", "1", "teams")
-                self._create_new_agent(self.new_agent_name, self.new_agent_bypass, teams)
+                # Step 4: Teams chosen, transition to provider step
+                self.new_agent_teams = text.lower().strip() in ("yes", "y", "true", "1", "teams")
+                self._handle_new_agent_provider_step()
+                event.input.value = ""
+                return
+            elif self.mode == "new_agent_provider":
+                # Step 5: Provider chosen, create agent
+                provider_input = text.lower().strip()
+                if provider_input in ("bedrock", "b"):
+                    self.new_agent_provider = "bedrock"
+                else:
+                    self.new_agent_provider = "web"
+                self._create_new_agent(self.new_agent_name, self.new_agent_bypass, self.new_agent_teams)
                 event.input.value = ""
                 self.action_clear_and_unfocus()
                 return
@@ -489,15 +502,31 @@ class CommandBar(Static):
             input_widget = self.query_one("#cmd-input", Input)
             input_widget.value = "yes"
 
+    def _handle_new_agent_provider_step(self) -> None:
+        """Transition to provider step. Pre-fills from config defaults."""
+        from ..config import get_new_agent_defaults
+        defaults = get_new_agent_defaults()
+        self.new_agent_provider = defaults.get("provider", "web")
+
+        self.mode = "new_agent_provider"
+        self._update_target_label()
+
+        # Pre-fill with current default
+        if self.new_agent_provider == "bedrock":
+            input_widget = self.query_one("#cmd-input", Input)
+            input_widget.value = "bedrock"
+
     def _create_new_agent(self, name: str, bypass_permissions: bool = False, agent_teams: bool = False) -> None:
-        """Create a new agent with the given name, directory, permission mode, and teams flag."""
-        self.post_message(self.NewAgentRequested(name, self.new_agent_dir, bypass_permissions, agent_teams, claude_agent=self.new_agent_claude_agent))
+        """Create a new agent with the given name, directory, permission mode, teams flag, and provider."""
+        provider = getattr(self, 'new_agent_provider', 'web') or 'web'
+        self.post_message(self.NewAgentRequested(name, self.new_agent_dir, bypass_permissions, agent_teams, claude_agent=self.new_agent_claude_agent, provider=provider))
         # Reset state
         self.new_agent_dir = None
         self.new_agent_name = None
         self.new_agent_bypass = False
         self.new_agent_teams = False
         self.new_agent_claude_agent = None
+        self.new_agent_provider = "web"
         self.mode = "send"
         self._update_target_label()
 
@@ -662,6 +691,7 @@ class CommandBar(Static):
         self.new_agent_bypass = False
         self.new_agent_teams = False
         self.new_agent_claude_agent = None
+        self.new_agent_provider = "web"
         self.new_remote_sister = None  # Reset remote agent state (#310)
         self.fork_source_session = None  # Reset fork state (#347)
         self.heartbeat_freq = None  # Reset heartbeat state (#171)

--- a/src/overcode/tui_widgets/session_summary.py
+++ b/src/overcode/tui_widgets/session_summary.py
@@ -56,6 +56,7 @@ class SessionSummary(Static, can_focus=True):
         self.any_has_oversight_timeout: bool = False  # True if any agent has oversight timeout
         self.any_is_sleeping: bool = False  # True if any agent is busy_sleeping (#289)
         self.any_has_model: bool = False  # True if any agent has a model set
+        self.any_has_provider: bool = False  # True if any agent uses non-web provider
         self.oversight_deadline: Optional[str] = None  # ISO deadline for this agent
         self.summarizer_enabled: bool = False  # Track if summarizer is enabled
         self.pane_content: List[str] = []  # Cached pane content
@@ -295,6 +296,8 @@ class SessionSummary(Static, can_focus=True):
             # Model
             model=s.model or getattr(s.stats, 'model', '') or "",
             any_has_model=self.any_has_model,
+            # Provider
+            any_has_provider=self.any_has_provider,
             # Sister integration (#245)
             source_host=s.source_host,
             is_remote=s.is_remote,


### PR DESCRIPTION
## Summary
- Adds `--provider` / `-P` launch flag to choose between `web` (Claude.ai OAuth) and `bedrock` (AWS Bedrock) per agent
- TUI launch dialog includes provider step, pre-filled from `new_agent_defaults.provider` config
- Injects `CLAUDE_CODE_USE_BEDROCK=1` and `AWS_REGION` as per-process env vars for bedrock agents
- Adds provider column (🌐/☁️) to agent list, only visible when mixed providers in use
- Bedrock region configurable via `bedrock.region` in config.yaml (default: us-east-1)

## Known issue
Something is failing at runtime — needs debugging before merge.

## Test plan
- [ ] Launch agent with `--provider bedrock` and verify `CLAUDE_CODE_USE_BEDROCK=1` is set in tmux env
- [ ] Launch agent with `--provider web` (or default) and verify no bedrock env vars
- [ ] Verify provider column appears only when mixed providers exist
- [ ] Test TUI launch dialog provider step
- [ ] Debug and fix the runtime failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)