### PR TITLE
Fix zero budget/tokens for agents with mismatched session paths

### DIFF
--- a/src/overcode/history_reader.py
+++ b/src/overcode/history_reader.py
@@ -650,8 +650,15 @@ def get_session_stats(
     interactions = hf.get_interactions_for_session(session)
     interaction_count = len(interactions)
 
-    # Derive Claude sessionIds from the already-scoped interactions
+    # Derive Claude sessionIds and their project paths from interactions.
+    # Claude Code may store session files under a different project path
+    # than start_directory (e.g., when the directory doesn't exist or Claude
+    # chooses a different project root).
     session_ids = {e.session_id for e in interactions if e.session_id}
+    sid_to_project: Dict[str, str] = {}
+    for e in interactions:
+        if e.session_id and e.project:
+            sid_to_project[e.session_id] = e.project
 
     # Active session ID for context window after /clear (#116)
     active_session_id = getattr(session, 'active_claude_session_id', None)
@@ -673,6 +680,16 @@ def get_session_stats(
         session_file = get_session_file_path(
             session.start_directory, sid, projects_path
         )
+        # Fall back to the project path from history entries if the session
+        # file doesn't exist at the expected start_directory path.  Claude
+        # Code may use a different project root (e.g. home dir) when the
+        # launch directory no longer exists.
+        if not session_file.exists():
+            alt_project = sid_to_project.get(sid)
+            if alt_project:
+                session_file = get_session_file_path(
+                    alt_project, sid, projects_path
+                )
         usage, work_times = read_session_file_stats(session_file, since=session_start)
         total_input += usage["input_tokens"]
         total_output += usage["output_tokens"]
@@ -695,7 +712,9 @@ def get_session_stats(
         all_work_times.extend(work_times)
 
         # Check for subagent files in {sessionId}/subagents/
-        encoded = encode_project_path(session.start_directory)
+        # Use the actual project path where the session file was found.
+        actual_project = sid_to_project.get(sid, session.start_directory)
+        encoded = encode_project_path(actual_project)
         subagents_dir = projects_path / encoded / sid / "subagents"
         if subagents_dir.exists():
             for subagent_file in subagents_dir.glob("agent-*.jsonl"):

--- a/src/overcode/monitor_daemon.py
+++ b/src/overcode/monitor_daemon.py
@@ -612,12 +612,16 @@ class MonitorDaemon:
         self.last_state_times[session_id] = now
 
     def sync_session_id(self, session) -> None:
-        """Detect and bind the current Claude session ID (#116, #373).
+        """Detect and bind Claude session IDs (#116, #373).
 
         For newly launched agents, the launcher prescribes --session-id at
-        launch and immediately binds it. This method handles post-/clear
-        detection: after /clear, Claude restarts with a new sessionId that
-        appears in history.jsonl.
+        launch and immediately binds it. This method handles two scenarios:
+
+        1. Post-/clear detection: after /clear, Claude restarts with a new
+           sessionId that appears in history.jsonl.
+        2. Unmatched prescribed IDs: when Claude Code doesn't honor
+           --session-id (e.g. after restart), the actual sessionIds need
+           to be discovered from history.jsonl.
 
         Uses an ownership guard to prevent cross-contamination when multiple
         agents share the same working directory — a sessionId already owned
@@ -630,11 +634,13 @@ class MonitorDaemon:
 
         try:
             session_start = datetime.fromisoformat(session.start_time)
+
+            # Fast path: discover the most recent sessionId for this directory.
+            # Handles post-/clear detection.
             current_id = get_current_session_id_for_directory(
                 session.start_directory, session_start
             )
             if current_id:
-                # Guard: don't steal a sessionId already owned by another agent
                 all_sessions = [
                     s for s in self.session_manager.list_sessions()
                     if s.tmux_session == self.tmux_session
@@ -642,8 +648,71 @@ class MonitorDaemon:
                 if not is_session_id_owned_by_others(current_id, session.id, all_sessions):
                     self.session_manager.add_claude_session_id(session.id, current_id)
                     self.session_manager.set_active_claude_session_id(session.id, current_id)
+
+            # Slow path: if the agent has owned session IDs but they produced
+            # zero tokens in the last stats sync, scan history.jsonl for ALL
+            # unowned sessionIds in this directory and adopt them.  This
+            # recovers from --session-id not being honored by Claude Code.
+            owned_ids = session.claude_session_ids or []
+            stats = session.stats
+            has_zero_tokens = (
+                owned_ids
+                and stats.input_tokens == 0
+                and stats.output_tokens == 0
+                and stats.last_stats_update is not None  # at least one sync happened
+            )
+            if has_zero_tokens:
+                self._discover_all_session_ids(session, session_start)
         except (ValueError, TypeError):
             pass
+
+    def _discover_all_session_ids(self, session, session_start: datetime) -> None:
+        """Scan history.jsonl for all unowned sessionIds in this directory.
+
+        When the prescribed --session-id wasn't honored by Claude Code,
+        the agent's actual sessionIds are unknown.  This scans all history
+        entries matching the directory+timestamp and adopts any sessionId
+        not already owned by another agent.
+        """
+        from .history_reader import HistoryFile
+        hf = HistoryFile()
+
+        session_dir = str(Path(session.start_directory).resolve())
+        session_start_ms = int(session_start.timestamp() * 1000)
+        owned_ids = set(session.claude_session_ids or [])
+
+        all_sessions = [
+            s for s in self.session_manager.list_sessions()
+            if s.tmux_session == self.tmux_session
+        ]
+
+        discovered = set()
+        latest_id = None
+        latest_ts = 0
+        for entry in hf.read_all():
+            if entry.timestamp_ms < session_start_ms:
+                continue
+            if not entry.project or not entry.session_id:
+                continue
+            entry_dir = str(Path(entry.project).resolve())
+            if entry_dir != session_dir:
+                continue
+            sid = entry.session_id
+            if sid in owned_ids:
+                continue
+            if is_session_id_owned_by_others(sid, session.id, all_sessions):
+                continue
+            discovered.add(sid)
+            if entry.timestamp_ms > latest_ts:
+                latest_ts = entry.timestamp_ms
+                latest_id = sid
+
+        for sid in discovered:
+            self.session_manager.add_claude_session_id(session.id, sid)
+            self.log.info(f"[{session.name}] Discovered unowned sessionId: {sid[:8]}...")
+
+        if latest_id:
+            self.session_manager.set_active_claude_session_id(session.id, latest_id)
 
     def sync_claude_code_stats(self, session) -> None:
         """Sync token/interaction stats from Claude Code history files."""


### PR DESCRIPTION
## Summary
- **Session file path mismatch**: `get_session_stats()` used `start_directory` to locate Claude Code session files, but Claude may store them under a different project root (e.g. home dir when the launch directory no longer exists). Now falls back to the `project` path from history.jsonl entries when the session file isn't found at the expected path.
- **Unowned session IDs in shared directories**: When `--session-id` isn't honored by Claude Code, the prescribed UUID has no session file. `sync_session_id()` only discovered the most recent sessionId, which was often owned by another agent in shared dirs. Added `_discover_all_session_ids()` that scans for ALL unowned sessionIds when an agent has zero tokens.

## Root cause
Agents `creative` and `hiveidea` showed $0.00 spend and zero tokens because:
1. `creative`: Claude Code stored session files under `-home-mkb23/` but overcode looked under `-home-mkb23-Code-creative/` (directory didn't exist on disk)
2. `hiveidea`: Prescribed `--session-id` wasn't honored; actual session IDs were owned by sibling agents (`phase1_benchmark`, etc.) in the shared directory, blocking discovery

## Test plan
- [x] All 336 stats-related unit tests pass
- [x] Verified `creative` now returns 253K tokens (was 0)
- [x] Verified `hiveidea` discovery finds 2 unowned sessions (292K tokens)
- [ ] Confirm TUI shows non-zero cost/tokens after daemon restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)