### PR TITLE
Add dispatch agent with auto-launch and RC keepalive (#23)

### DIFF
--- a/src/overcode/cli/__init__.py
+++ b/src/overcode/cli/__init__.py
@@ -23,6 +23,7 @@ from . import sister  # noqa: F401
 from . import config  # noqa: F401
 from . import split  # noqa: F401
 from . import jobs  # noqa: F401
+from . import rc  # noqa: F401
 
 
 def main():

--- a/src/overcode/cli/config.py
+++ b/src/overcode/cli/config.py
@@ -57,6 +57,13 @@ CONFIG_TEMPLATE = """\
 #   - name: "desktop"
 #     url: "http://192.168.1.10:5337"
 #     api_key: "shared-secret"
+
+# Dispatch agent — persistent session with /remote-control kept alive
+# dispatch:
+#   enabled: false
+#   name: dispatch                    # Session name
+#   directory: ~/.overcode/dispatch   # Working directory
+#   rc_keepalive_interval: 120        # Seconds between RC keepalive checks
 """
 
 

--- a/src/overcode/cli/rc.py
+++ b/src/overcode/cli/rc.py
@@ -1,0 +1,65 @@
+"""
+Remote control toggle for agents.
+
+Sends Claude Code's /remote-control slash command to an agent's tmux pane
+to enable or disable remote connections from claude.ai/code.
+"""
+
+from typing import Annotated
+
+import typer
+from rich import print as rprint
+
+from ._shared import app, SessionOption
+
+
+@app.command("rc")
+def rc(
+    name: Annotated[str, typer.Argument(help="Name of agent")],
+    action: Annotated[str, typer.Argument(help="'on' or 'off'")],
+    session: SessionOption = "agents",
+):
+    """Toggle /remote-control on an agent.
+
+    Enables or disables Claude Code's built-in remote control,
+    which allows connections from claude.ai/code or the mobile app.
+
+    Examples:
+        overcode rc dispatch on    # Enable remote control
+        overcode rc dispatch off   # Disable remote control
+    """
+    from ..launcher import ClaudeLauncher
+    from ..session_manager import SessionManager
+
+    if action not in ("on", "off"):
+        rprint(f"[red]Error: action must be 'on' or 'off', got '{action}'[/red]")
+        raise typer.Exit(1)
+
+    sm = SessionManager()
+    agent_session = sm.get_session_by_name(name)
+    if not agent_session:
+        rprint(f"[red]Error: agent '{name}' not found[/red]")
+        raise typer.Exit(1)
+
+    # Auto-wake sleeping agent
+    if agent_session.is_asleep:
+        sm.update_session(agent_session.id, is_asleep=False)
+        rprint(f"[dim]Woke agent '{name}'[/dim]")
+
+    launcher = ClaudeLauncher(session)
+
+    if action == "on":
+        success = launcher.send_to_session(name, "/remote-control")
+        if success:
+            rprint(f"[green]✓[/green] Sent /remote-control to '[bold]{name}[/bold]'")
+        else:
+            rprint(f"[red]✗[/red] Failed to send to '[bold]{name}[/bold]'")
+            raise typer.Exit(1)
+    else:
+        # Send Escape to dismiss RC mode
+        success = launcher.send_to_session(name, "escape", enter=False)
+        if success:
+            rprint(f"[green]✓[/green] Sent Escape to '[bold]{name}[/bold]' (RC off)")
+        else:
+            rprint(f"[red]✗[/red] Failed to send to '[bold]{name}[/bold]'")
+            raise typer.Exit(1)

--- a/src/overcode/config.py
+++ b/src/overcode/config.py
@@ -93,6 +93,32 @@ def get_relay_config() -> Optional[dict]:
     }
 
 
+def get_dispatch_config() -> Optional[dict]:
+    """Get dispatch agent configuration.
+
+    Returns None if dispatch is not enabled.
+
+    Config format in ~/.overcode/config.yaml:
+        dispatch:
+          enabled: true
+          name: dispatch                    # session name (default "dispatch")
+          directory: ~/.overcode/dispatch   # working directory (default)
+          rc_keepalive_interval: 120        # seconds between RC checks (default 120)
+    """
+    if not _get_config_value("dispatch.enabled", False):
+        return None
+
+    return {
+        "name": _get_config_value("dispatch.name", "dispatch"),
+        "directory": str(Path(_get_config_value(
+            "dispatch.directory", "~/.overcode/dispatch"
+        )).expanduser()),
+        "rc_keepalive_interval": _get_config_value(
+            "dispatch.rc_keepalive_interval", 120
+        ),
+    }
+
+
 def get_summarizer_config() -> dict:
     """Get summarizer configuration for AI summaries.
 

--- a/src/overcode/monitor_daemon.py
+++ b/src/overcode/monitor_daemon.py
@@ -79,7 +79,7 @@ from .monitor_daemon_core import (
     should_auto_archive,
     should_enforce_oversight_timeout,
 )
-from .tmux_utils import send_text_to_tmux_window
+from .tmux_utils import send_text_to_tmux_window, get_tmux_pane_content
 
 
 # Check for macOS presence APIs (optional)
@@ -336,6 +336,9 @@ class MonitorDaemon:
 
         # Legacy migration flag — runs once on first tick
         self._legacy_windows_migrated = False
+
+        # Dispatch agent lifecycle (#23)
+        self._last_rc_check: Optional[datetime] = None
 
     def _migrate_legacy_window_ids(self, sessions: list) -> None:
         """Migrate legacy digit-string tmux_window values to actual window names."""
@@ -982,6 +985,83 @@ class MonitorDaemon:
         session_states, all_waiting = self._detect_and_enrich(sessions, now)
         self._cleanup_stale(sessions)
         self._publish_and_enforce(sessions, session_states, all_waiting)
+        self._ensure_dispatch(sessions, now)
+
+    # ------------------------------------------------------------------
+    # Dispatch agent lifecycle (#23)
+    # ------------------------------------------------------------------
+
+    def _ensure_dispatch(self, sessions: list, now: datetime) -> None:
+        """Ensure the dispatch agent is running and has /remote-control active."""
+        from .config import get_dispatch_config
+        config = get_dispatch_config()
+        if not config:
+            return
+
+        dispatch_name = config["name"]
+        dispatch_session = None
+        for s in sessions:
+            if s.name == dispatch_name:
+                dispatch_session = s
+                break
+
+        if dispatch_session is None or dispatch_session.status == "terminated":
+            # Launch dispatch agent
+            from pathlib import Path
+            Path(config["directory"]).mkdir(parents=True, exist_ok=True)
+            from .launcher import ClaudeLauncher
+            launcher = ClaudeLauncher(self.tmux_session)
+            result = launcher.launch(
+                name=dispatch_name,
+                start_directory=config["directory"],
+                skip_permissions=True,
+            )
+            if result:
+                self.log.info(f"Dispatch agent '{dispatch_name}' launched")
+            else:
+                self.log.warn(f"Failed to launch dispatch agent '{dispatch_name}'")
+            return
+
+        # Session exists and is alive — ensure RC is active
+        self._ensure_dispatch_rc(dispatch_session, config, now)
+
+    def _ensure_dispatch_rc(self, session, config: dict, now: datetime) -> None:
+        """Ensure dispatch agent has /remote-control active."""
+        interval = config.get("rc_keepalive_interval", 120)
+        if self._last_rc_check and (now - self._last_rc_check).total_seconds() < interval:
+            return
+        self._last_rc_check = now
+
+        pane_content = get_tmux_pane_content(
+            self.tmux_session, session.tmux_window, lines=20
+        )
+        if not pane_content:
+            return
+
+        # Check if RC appears active
+        if self._is_rc_active(pane_content):
+            return
+
+        # RC not active — check if agent is at an idle prompt before sending
+        from .status_patterns import is_prompt_line
+        lines = pane_content.strip().split("\n")
+        for line in reversed(lines[-5:]):
+            if is_prompt_line(line):
+                send_text_to_tmux_window(
+                    self.tmux_session, session.tmux_window,
+                    "/remote-control", send_enter=True,
+                )
+                self.log.info("Dispatch: re-sent /remote-control")
+                break
+
+    @staticmethod
+    def _is_rc_active(pane_content: str) -> bool:
+        """Check if /remote-control appears to be active in pane content."""
+        for line in pane_content.split("\n")[-10:]:
+            lower = line.lower()
+            if "remote control" in lower or "waiting for connection" in lower:
+                return True
+        return False
 
     def _sync_session_ids(self, sessions: list, now: datetime) -> None:
         """Fast session ID detection every 10s (#116).

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -783,3 +783,45 @@ sisters:
 
         result = config.get_sisters_config()
         assert result == []
+
+
+class TestGetDispatchConfig:
+    """Test dispatch agent configuration retrieval (#23)."""
+
+    def test_returns_none_when_disabled(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("dispatch:\n  enabled: false\n")
+        monkeypatch.setattr(config, "CONFIG_PATH", config_file)
+        assert config.get_dispatch_config() is None
+
+    def test_returns_none_when_not_configured(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("tmux_session: agents\n")
+        monkeypatch.setattr(config, "CONFIG_PATH", config_file)
+        assert config.get_dispatch_config() is None
+
+    def test_returns_config_when_enabled(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("dispatch:\n  enabled: true\n  name: mybot\n  rc_keepalive_interval: 60\n")
+        monkeypatch.setattr(config, "CONFIG_PATH", config_file)
+        result = config.get_dispatch_config()
+        assert result is not None
+        assert result["name"] == "mybot"
+        assert result["rc_keepalive_interval"] == 60
+
+    def test_uses_defaults(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("dispatch:\n  enabled: true\n")
+        monkeypatch.setattr(config, "CONFIG_PATH", config_file)
+        result = config.get_dispatch_config()
+        assert result["name"] == "dispatch"
+        assert result["rc_keepalive_interval"] == 120
+        assert result["directory"].endswith(".overcode/dispatch")
+
+    def test_directory_expanded(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("dispatch:\n  enabled: true\n  directory: ~/my-dispatch\n")
+        monkeypatch.setattr(config, "CONFIG_PATH", config_file)
+        result = config.get_dispatch_config()
+        assert "~" not in result["directory"]
+        assert result["directory"].endswith("my-dispatch")

--- a/tests/unit/test_monitor_daemon.py
+++ b/tests/unit/test_monitor_daemon.py
@@ -1669,6 +1669,136 @@ class TestCountUntrackedWindows:
             assert result == 0
 
 
+class TestEnsureDispatch:
+    """Test dispatch agent lifecycle management (#23)."""
+
+    def _make_daemon(self):
+        """Create a MonitorDaemon with mocked dependencies."""
+        from overcode.monitor_daemon import MonitorDaemon
+        daemon = MonitorDaemon.__new__(MonitorDaemon)
+        daemon.tmux_session = "agents"
+        daemon.session_manager = MagicMock()
+        daemon.log = MagicMock()
+        daemon._last_rc_check = None
+        return daemon
+
+    @patch("overcode.monitor_daemon.get_tmux_pane_content")
+    def test_noop_when_disabled(self, mock_pane):
+        daemon = self._make_daemon()
+        now = datetime.now()
+        with patch("overcode.config.get_dispatch_config", return_value=None):
+            daemon._ensure_dispatch([], now)
+        mock_pane.assert_not_called()
+
+    @patch("overcode.launcher.ClaudeLauncher")
+    def test_launches_when_no_session(self, mock_launcher_cls, tmp_path):
+        daemon = self._make_daemon()
+        now = datetime.now()
+        mock_launcher = MagicMock()
+        mock_launcher.launch.return_value = MagicMock()
+        mock_launcher_cls.return_value = mock_launcher
+        config = {"name": "dispatch", "directory": str(tmp_path / "dispatch"), "rc_keepalive_interval": 120}
+        with patch("overcode.config.get_dispatch_config", return_value=config):
+            daemon._ensure_dispatch([], now)
+        mock_launcher.launch.assert_called_once_with(
+            name="dispatch",
+            start_directory=str(tmp_path / "dispatch"),
+            skip_permissions=True,
+        )
+
+    def test_noop_when_session_alive(self):
+        daemon = self._make_daemon()
+        now = datetime.now()
+        session = MagicMock()
+        session.name = "dispatch"
+        session.status = "running"
+        session.tmux_window = "dispatch-abcd"
+        config = {"name": "dispatch", "directory": "/tmp/dispatch", "rc_keepalive_interval": 120}
+        with patch("overcode.config.get_dispatch_config", return_value=config), \
+             patch.object(daemon, "_ensure_dispatch_rc") as mock_rc:
+            daemon._ensure_dispatch([session], now)
+        mock_rc.assert_called_once_with(session, config, now)
+
+    @patch("overcode.launcher.ClaudeLauncher")
+    def test_relaunches_when_terminated(self, mock_launcher_cls, tmp_path):
+        daemon = self._make_daemon()
+        now = datetime.now()
+        mock_launcher = MagicMock()
+        mock_launcher.launch.return_value = MagicMock()
+        mock_launcher_cls.return_value = mock_launcher
+        session = MagicMock()
+        session.name = "dispatch"
+        session.status = "terminated"
+        config = {"name": "dispatch", "directory": str(tmp_path / "dispatch"), "rc_keepalive_interval": 120}
+        with patch("overcode.config.get_dispatch_config", return_value=config):
+            daemon._ensure_dispatch([session], now)
+        mock_launcher.launch.assert_called_once()
+
+
+class TestIsRcActive:
+    """Test RC detection heuristic (#23)."""
+
+    def test_detects_remote_control_text(self):
+        from overcode.monitor_daemon import MonitorDaemon
+        content = "some output\nRemote control is active\n>"
+        assert MonitorDaemon._is_rc_active(content) is True
+
+    def test_detects_waiting_for_connection(self):
+        from overcode.monitor_daemon import MonitorDaemon
+        content = "Waiting for connection from claude.ai\n>"
+        assert MonitorDaemon._is_rc_active(content) is True
+
+    def test_returns_false_for_normal_prompt(self):
+        from overcode.monitor_daemon import MonitorDaemon
+        content = "Task completed successfully.\n❯"
+        assert MonitorDaemon._is_rc_active(content) is False
+
+
+class TestEnsureDispatchRc:
+    """Test RC keepalive logic (#23)."""
+
+    def _make_daemon(self):
+        from overcode.monitor_daemon import MonitorDaemon
+        daemon = MonitorDaemon.__new__(MonitorDaemon)
+        daemon.tmux_session = "agents"
+        daemon.log = MagicMock()
+        daemon._last_rc_check = None
+        return daemon
+
+    @patch("overcode.monitor_daemon.send_text_to_tmux_window")
+    @patch("overcode.monitor_daemon.get_tmux_pane_content", return_value="Task done\n❯")
+    def test_resends_rc_when_at_prompt(self, mock_pane, mock_send):
+        daemon = self._make_daemon()
+        session = MagicMock()
+        session.tmux_window = "dispatch-abcd"
+        config = {"rc_keepalive_interval": 0}
+        daemon._ensure_dispatch_rc(session, config, datetime.now())
+        mock_send.assert_called_once_with(
+            "agents", "dispatch-abcd", "/remote-control", send_enter=True
+        )
+
+    @patch("overcode.monitor_daemon.send_text_to_tmux_window")
+    @patch("overcode.monitor_daemon.get_tmux_pane_content", return_value="Remote control active\n❯")
+    def test_skips_when_rc_active(self, mock_pane, mock_send):
+        daemon = self._make_daemon()
+        session = MagicMock()
+        session.tmux_window = "dispatch-abcd"
+        config = {"rc_keepalive_interval": 0}
+        daemon._ensure_dispatch_rc(session, config, datetime.now())
+        mock_send.assert_not_called()
+
+    @patch("overcode.monitor_daemon.send_text_to_tmux_window")
+    @patch("overcode.monitor_daemon.get_tmux_pane_content", return_value="Task done\n❯")
+    def test_respects_interval(self, mock_pane, mock_send):
+        daemon = self._make_daemon()
+        daemon._last_rc_check = datetime.now()  # Just checked
+        session = MagicMock()
+        session.tmux_window = "dispatch-abcd"
+        config = {"rc_keepalive_interval": 120}
+        daemon._ensure_dispatch_rc(session, config, datetime.now())
+        mock_pane.assert_not_called()  # Skipped due to interval
+
+
 # =============================================================================
 # Run tests directly
 # =============================================================================


### PR DESCRIPTION
## Summary
- Adds a persistent "dispatch" Claude Code session managed by the monitor daemon, with `/remote-control` kept alive for phone/browser access via claude.ai/code
- New `overcode rc <name> on/off` CLI command to toggle remote control on any agent
- Config via `dispatch:` section in `~/.overcode/config.yaml` (opt-in, disabled by default)

## Changes
| File | Change |
|------|--------|
| `config.py` | `get_dispatch_config()` getter |
| `cli/config.py` | Dispatch section in config template |
| `cli/rc.py` | **New** — `overcode rc` command |
| `cli/__init__.py` | Register rc module |
| `monitor_daemon.py` | `_ensure_dispatch()`, `_ensure_dispatch_rc()`, `_is_rc_active()` |
| `tests/` | 15 new tests (config + daemon lifecycle + RC keepalive) |

## How it works
1. Set `dispatch.enabled: true` in config.yaml
2. Monitor daemon auto-launches a dispatch agent on next tick
3. Every 120s (configurable), daemon checks if RC is active; re-sends `/remote-control` if agent is idle and RC has dropped
4. If dispatch agent crashes or is killed, daemon re-launches it automatically

## Test plan
- [x] 15 new unit tests pass
- [x] Full test suite passes (3240 passed)
- [ ] Manual: enable dispatch in config, verify auto-launch
- [ ] Manual: kill dispatch window, verify re-launch
- [ ] Manual: `overcode rc dispatch on/off`
- [ ] Manual: verify RC keepalive after timeout

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)