### PR TITLE
Perf + refactoring: audit issues #371 and #372

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -14,11 +14,8 @@ python_functions = test_*
 
 # Output options
 addopts =
-    -v
     --tb=short
     --strict-markers
-    --capture=no
-    -s
     -m "not e2e"
 
 # Test paths

--- a/src/overcode/config.py
+++ b/src/overcode/config.py
@@ -9,6 +9,7 @@ Example config:
 """
 
 import socket
+import time
 from pathlib import Path
 from typing import List, Optional
 import yaml
@@ -16,27 +17,65 @@ import yaml
 
 CONFIG_PATH = Path.home() / ".overcode" / "config.yaml"
 
+# TTL-based config cache to avoid file I/O + YAML parse on every access
+_config_cache: dict | None = None
+_config_cache_time: float = 0.0
+_config_cache_mtime: float = 0.0
+_CONFIG_CACHE_TTL: float = 5.0  # seconds
+
+
+def _clear_config_cache() -> None:
+    """Clear the config cache. Useful for testing."""
+    global _config_cache, _config_cache_time, _config_cache_mtime
+    _config_cache = None
+    _config_cache_time = 0.0
+    _config_cache_mtime = 0.0
+
 
 def save_config(config: dict) -> None:
     """Save configuration dict to ~/.overcode/config.yaml."""
+    global _config_cache, _config_cache_time, _config_cache_mtime
     CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     CONFIG_PATH.write_text(yaml.dump(config, default_flow_style=False, sort_keys=False))
+    # Invalidate cache so next read picks up the write
+    _config_cache = None
+    _config_cache_time = 0.0
 
 
 def load_config() -> dict:
     """Load configuration from ~/.overcode/config.yaml.
 
     Returns empty dict if file doesn't exist or is invalid.
+    Uses a TTL + mtime cache to avoid repeated file I/O.
     """
+    global _config_cache, _config_cache_time, _config_cache_mtime
+
+    now = time.monotonic()
+    if _config_cache is not None and (now - _config_cache_time) < _CONFIG_CACHE_TTL:
+        return _config_cache
+
     if not CONFIG_PATH.exists():
-        return {}
+        _config_cache = {}
+        _config_cache_time = now
+        return _config_cache
 
     try:
+        mtime = CONFIG_PATH.stat().st_mtime
+        # If file hasn't changed since last parse, reuse cached result
+        if _config_cache is not None and mtime == _config_cache_mtime:
+            _config_cache_time = now
+            return _config_cache
+
         with open(CONFIG_PATH) as f:
             config = yaml.safe_load(f)
-            return config if isinstance(config, dict) else {}
+            _config_cache = config if isinstance(config, dict) else {}
+            _config_cache_time = now
+            _config_cache_mtime = mtime
+            return _config_cache
     except (yaml.YAMLError, IOError):
-        return {}
+        _config_cache = {}
+        _config_cache_time = now
+        return _config_cache
 
 
 def _get_config_value(key_path: str, default=None):

--- a/src/overcode/presence_logger.py
+++ b/src/overcode/presence_logger.py
@@ -392,8 +392,16 @@ def get_current_presence_state(tui_active: bool = False) -> tuple[int, float, bo
     return state, idle, locked
 
 
+_presence_cache: list[tuple[dt.datetime, int]] = []
+_presence_cache_mtime: float = 0.0
+_presence_cache_size: int = 0
+_presence_cache_hours: float = 0.0
+
+
 def read_presence_history(hours: float = 3.0) -> list[tuple[dt.datetime, int]]:
     """Read presence history from CSV file.
+
+    Uses mtime+size cache to avoid re-parsing unchanged files.
 
     Args:
         hours: How many hours of history to read (default 3)
@@ -401,9 +409,22 @@ def read_presence_history(hours: float = 3.0) -> list[tuple[dt.datetime, int]]:
     Returns:
         List of (timestamp, state) tuples, oldest first
     """
+    global _presence_cache, _presence_cache_mtime, _presence_cache_size, _presence_cache_hours
+
     log_path = default_log_path()
     if not Path(log_path).exists():
         return []
+
+    try:
+        stat = Path(log_path).stat()
+    except OSError:
+        return []
+
+    # Return cached result if file unchanged and same hours window
+    if (stat.st_mtime == _presence_cache_mtime
+            and stat.st_size == _presence_cache_size
+            and hours == _presence_cache_hours):
+        return _presence_cache
 
     cutoff = dt.datetime.now() - dt.timedelta(hours=hours)
     history = []
@@ -421,6 +442,11 @@ def read_presence_history(hours: float = 3.0) -> list[tuple[dt.datetime, int]]:
                     continue
     except (OSError, IOError):
         pass
+
+    _presence_cache = history
+    _presence_cache_mtime = stat.st_mtime
+    _presence_cache_size = stat.st_size
+    _presence_cache_hours = hours
 
     return history
 

--- a/src/overcode/standing_instructions.py
+++ b/src/overcode/standing_instructions.py
@@ -22,6 +22,27 @@ class InstructionPreset:
     instructions: str   # Full instruction text for daemon claude
 
 
+# Shared handover instruction sent to agents during transport-all operations.
+# Used by both tui_actions/session.py and web_control_api.py.
+HANDOVER_INSTRUCTION = (
+    "Please prepare for handover. Follow these steps in order:\n\n"
+    "1. Check your current branch with `git branch --show-current`\n"
+    "   - If on main or master, create and switch to a new branch:\n"
+    "     `git checkout -b handover/<brief-task-description>`\n"
+    "   - Never push directly to main/master\n\n"
+    "2. Commit all your current changes with a descriptive commit message\n\n"
+    "3. Push to your branch: `git push -u origin <branch-name>`\n\n"
+    "4. Check if a PR exists: `gh pr list --head $(git branch --show-current)`\n"
+    "   - If no PR exists, create a draft PR:\n"
+    "     `gh pr create --draft --title '<brief title>' --body 'WIP'`\n\n"
+    "5. Post a handover comment on the PR using `gh pr comment` with:\n"
+    "   - What you've accomplished\n"
+    "   - Current state of the work\n"
+    "   - Any pending tasks or next steps\n"
+    "   - Known issues or blockers"
+)
+
+
 # Default presets - used to generate initial presets.json
 DEFAULT_PRESETS: Dict[str, InstructionPreset] = {
     "DO_NOTHING": InstructionPreset(

--- a/src/overcode/summarizer_component.py
+++ b/src/overcode/summarizer_component.py
@@ -205,55 +205,53 @@ class SummarizerComponent:
         self, session, summary: AgentSummary, content: str, status: str, now: datetime
     ) -> None:
         """Update the short (current activity) summary."""
-        try:
-            result = self._client.summarize(
-                pane_content=content,
-                previous_summary=summary.text,
-                current_status=status,
-                lines=self.config.lines,
-                max_tokens=50,  # Aggressive limit for terse output
-                mode="short",
-            )
-
-            self.total_calls += 1
-            self._accumulate_cost()
-
-            if result and result.strip().upper() != "UNCHANGED":
-                summary.text = result.strip()
-                summary.updated_at = now.isoformat()
-                logger.debug(f"Updated short summary for {session.name}: {result[:50]}...")
-
-            self._last_update[session.id] = now
-
-        except Exception as e:
-            logger.warning(f"Short summary error for {session.name}: {e}")
+        self._update_summary(session, summary, content, status, now, mode="short")
 
     def _update_context_summary(
         self, session, summary: AgentSummary, content: str, status: str, now: datetime
     ) -> None:
         """Update the context (wider context) summary."""
+        self._update_summary(session, summary, content, status, now, mode="context")
+
+    def _update_summary(
+        self, session, summary: AgentSummary, content: str, status: str, now: datetime,
+        mode: str = "short",
+    ) -> None:
+        """Update a summary field (short or context) via the AI client."""
+        is_short = mode == "short"
+        previous = summary.text if is_short else summary.context
+        max_tokens = 50 if is_short else 75
+
         try:
             result = self._client.summarize(
                 pane_content=content,
-                previous_summary=summary.context,
+                previous_summary=previous,
                 current_status=status,
                 lines=self.config.lines,
-                max_tokens=75,  # Aggressive limit for terse output
-                mode="context",
+                max_tokens=max_tokens,
+                mode=mode,
             )
 
             self.total_calls += 1
             self._accumulate_cost()
 
             if result and result.strip().upper() != "UNCHANGED":
-                summary.context = result.strip()
-                summary.context_updated_at = now.isoformat()
-                logger.debug(f"Updated context summary for {session.name}: {result[:50]}...")
+                stripped = result.strip()
+                if is_short:
+                    summary.text = stripped
+                    summary.updated_at = now.isoformat()
+                else:
+                    summary.context = stripped
+                    summary.context_updated_at = now.isoformat()
+                logger.debug(f"Updated {mode} summary for {session.name}: {stripped[:50]}...")
 
-            self._last_context_update[session.id] = now
+            if is_short:
+                self._last_update[session.id] = now
+            else:
+                self._last_context_update[session.id] = now
 
         except Exception as e:
-            logger.warning(f"Context summary error for {session.name}: {e}")
+            logger.warning(f"{mode.capitalize()} summary error for {session.name}: {e}")
 
     def _accumulate_cost(self) -> None:
         """Accumulate cost from the most recent API call."""

--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -261,6 +261,7 @@ class SupervisorTUI(
         self.max_name_width: int = 10
         self.all_names_match_repos: bool = False
         self.column_widths: list = []  # Per-cell column widths for alignment
+        self._column_widths_dirty: bool = True  # Recompute on first render
 
         # Load persisted TUI preferences
         self._prefs = TUIPreferences.load(tmux_session)
@@ -336,6 +337,8 @@ class SupervisorTUI(
         self._notifier = MacNotifier(mode=self._prefs.notifications)
         # Cache of terminated sessions (killed during this TUI session)
         self._terminated_sessions: dict[str, Session] = {}
+        self._terminated_times: dict[str, float] = {}  # session_id -> monotonic time
+        self._TERMINATED_GC_SECONDS: float = 600.0  # 10 minutes
 
         # Usage monitor (Claude Code subscription limits)
         self._usage_monitor = UsageMonitor()
@@ -759,6 +762,7 @@ class SupervisorTUI(
         """Recalculate max name/repo/branch widths and name-match flag.
 
         Returns True if any width or flag actually changed.
+        Also marks column widths dirty when changes are detected.
         """
         old = (self.max_name_width, self.max_repo_width, self.max_branch_width, self.all_names_match_repos)
         sessions = list(sessions)
@@ -780,23 +784,32 @@ class SupervisorTUI(
             self.max_repo_width = 10
             self.max_branch_width = 10
             self.all_names_match_repos = False
-        return old != (self.max_name_width, self.max_repo_width, self.max_branch_width, self.all_names_match_repos)
+        changed = old != (self.max_name_width, self.max_repo_width, self.max_branch_width, self.all_names_match_repos)
+        if changed:
+            self._column_widths_dirty = True
+        return changed
 
-    def _recompute_cell_column_widths(self) -> None:
+    def _recompute_cell_column_widths(self, force: bool = False) -> None:
         """Recompute per-cell column widths across all visible widgets.
 
         Collects render_summary_cells() output from every SessionSummary
         widget, then computes max visual width per column position. Stored
         as self.column_widths for use by widget render() via pad_and_join_cells().
 
+        Skips recomputation if not dirty (no structural changes since last call)
+        unless force=True.
+
         This ensures all widgets align perfectly regardless of content width.
         Same compute_column_widths() function is used by CLI's align_summary_rows(),
         so testing `overcode list` validates the TUI alignment code.
         """
+        if not force and not self._column_widths_dirty:
+            return
         from .summary_columns import render_summary_cells, compute_column_widths
         widgets = list(self.query(SessionSummary))
         if not widgets:
             self.column_widths = []
+            self._column_widths_dirty = False
             return
         all_cells = []
         for w in widgets:
@@ -804,6 +817,7 @@ class SupervisorTUI(
             cells = render_summary_cells(ctx, column_filter=w.column_visible)
             all_cells.append(cells)
         self.column_widths = compute_column_widths(all_cells)
+        self._column_widths_dirty = False
         # Update column headers if visible
         self._update_column_headers()
 
@@ -1533,8 +1547,23 @@ class SupervisorTUI(
         self._notifier.flush()
         self._mark_event("apply_status_end")
 
+    def _gc_terminated_sessions(self) -> None:
+        """Remove terminated sessions older than _TERMINATED_GC_SECONDS."""
+        if not self._terminated_times:
+            return
+        import time as _time
+        now = _time.monotonic()
+        expired = [
+            sid for sid, t in self._terminated_times.items()
+            if (now - t) > self._TERMINATED_GC_SECONDS
+        ]
+        for sid in expired:
+            del self._terminated_sessions[sid]
+            del self._terminated_times[sid]
+
     def _apply_stats_results(self, stats_results: dict, git_diff_results: dict) -> None:
         """Apply slow-path stats results to widgets (runs on main thread)."""
+        self._gc_terminated_sessions()
         self._mark_event("apply_stats_start")
         changed_widgets = []
         for widget in self.query(SessionSummary):
@@ -1549,6 +1578,7 @@ class SupervisorTUI(
             if claude_stats is not None or git_diff is not None:
                 changed_widgets.append(widget)
         if changed_widgets:
+            self._column_widths_dirty = True
             self._recompute_cell_column_widths()
             for widget in changed_widgets:
                 widget.refresh()
@@ -1766,6 +1796,7 @@ class SupervisorTUI(
                     if changed:
                         widget.refresh()
             # Recompute cell column widths for alignment after data update
+            self._column_widths_dirty = True
             self._recompute_cell_column_widths()
             # Still reorder widgets to handle sort mode changes
             self._reorder_session_widgets(container)
@@ -1837,6 +1868,7 @@ class SupervisorTUI(
         # This must run after any structural changes AND after sort mode changes
         self._reorder_session_widgets(container)
         # Recompute cell column widths for alignment after structural changes
+        self._column_widths_dirty = True
         self._recompute_cell_column_widths()
         self._restore_focus_in_update(_focused_session_id, _focus_was_on_session)
 
@@ -3066,7 +3098,9 @@ class SupervisorTUI(
             self.notify(f"Killed agent: {session_name}", severity="information")
 
             # Store in terminated sessions cache for ghost mode
+            import time as _time
             self._terminated_sessions[session_id] = terminated_session
+            self._terminated_times[session_id] = _time.monotonic()
 
             # Remove from self.sessions so j/k ordering stays consistent
             self.sessions = [s for s in self.sessions if s.id != session_id]
@@ -3100,6 +3134,7 @@ class SupervisorTUI(
         # Remove from caches
         if session_id in self._terminated_sessions:
             del self._terminated_sessions[session_id]
+        self._terminated_times.pop(session_id, None)
         if session_id in self._sessions_cache:
             del self._sessions_cache[session_id]
         # Remove the widget
@@ -3240,6 +3275,7 @@ class SupervisorTUI(
         # Remove from terminated cache
         if session.id in self._terminated_sessions:
             del self._terminated_sessions[session.id]
+        self._terminated_times.pop(session.id, None)
 
         resume_info = " (resuming session)" if session.active_claude_session_id else ""
         self.notify(f"Revived agent: {session_name}{resume_info}", severity="information")
@@ -3279,6 +3315,7 @@ class SupervisorTUI(
         for widget in self.query(SessionSummary):
             widget.column_overrides = new_overrides
             widget.refresh()
+        self._column_widths_dirty = True
         self._recompute_cell_column_widths()
 
         self.notify(f"Column config saved for {level}", severity="information")
@@ -3292,6 +3329,7 @@ class SupervisorTUI(
         for widget in self.query(SessionSummary):
             widget.column_overrides = original_overrides
             widget.refresh()
+        self._column_widths_dirty = True
         self._recompute_cell_column_widths()
         self._dialog_did_close()
 

--- a/src/overcode/tui_actions/session.py
+++ b/src/overcode/tui_actions/session.py
@@ -654,24 +654,8 @@ class SessionActionsMixin:
         """Execute transport/handover instructions to all sessions."""
         from ..launcher import ClaudeLauncher
 
-        # The handover instruction to send to each agent
-        handover_instruction = (
-            "Please prepare for handover. Follow these steps in order:\n\n"
-            "1. Check your current branch with `git branch --show-current`\n"
-            "   - If on main or master, create and switch to a new branch:\n"
-            "     `git checkout -b handover/<brief-task-description>`\n"
-            "   - Never push directly to main/master\n\n"
-            "2. Commit all your current changes with a descriptive commit message\n\n"
-            "3. Push to your branch: `git push -u origin <branch-name>`\n\n"
-            "4. Check if a PR exists: `gh pr list --head $(git branch --show-current)`\n"
-            "   - If no PR exists, create a draft PR:\n"
-            "     `gh pr create --draft --title '<brief title>' --body 'WIP'`\n\n"
-            "5. Post a handover comment on the PR using `gh pr comment` with:\n"
-            "   - What you've accomplished\n"
-            "   - Current state of the work\n"
-            "   - Any pending tasks or next steps\n"
-            "   - Known issues or blockers"
-        )
+        from ..standing_instructions import HANDOVER_INSTRUCTION
+        handover_instruction = HANDOVER_INSTRUCTION
 
         launcher = ClaudeLauncher(
             tmux_session=self.tmux_session,

--- a/src/overcode/tui_widgets/__init__.py
+++ b/src/overcode/tui_widgets/__init__.py
@@ -14,6 +14,7 @@ from .daemon_status_bar import DaemonStatusBar
 from .status_timeline import StatusTimeline
 from .session_summary import SessionSummary
 from .command_bar import CommandBar
+from .modal_base import ModalBase
 from .summary_config_modal import SummaryConfigModal
 from .new_agent_defaults_modal import NewAgentDefaultsModal
 from .agent_select_modal import AgentSelectModal

--- a/src/overcode/tui_widgets/agent_select_modal.py
+++ b/src/overcode/tui_widgets/agent_select_modal.py
@@ -4,18 +4,16 @@ Agent selection modal for TUI.
 Keyboard-navigable list to pick a Claude agent persona before launching.
 """
 
-import logging
 from typing import List, Optional, Any
 
-from textual.widgets import Static
 from textual.message import Message
 from textual import events
 from rich.text import Text
 
-logger = logging.getLogger(__name__)
+from .modal_base import ModalBase
 
 
-class AgentSelectModal(Static, can_focus=True):
+class AgentSelectModal(ModalBase):
     """Modal dialog for selecting a Claude agent.
 
     Navigate with j/k or up/down arrows.
@@ -36,9 +34,6 @@ class AgentSelectModal(Static, can_focus=True):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._agents: List[str] = []
-        self.selected_index: int = 0
-        self._app_ref: Optional[Any] = None
-        self._previous_focus: Optional[Any] = None
 
     def render(self) -> Text:
         text = Text()
@@ -62,39 +57,20 @@ class AgentSelectModal(Static, can_focus=True):
         return text
 
     def on_key(self, event: events.Key) -> None:
-        key = event.key
         total = 1 + len(self._agents)  # (none) + agent names
+        if self._navigate(event, total):
+            return
 
-        if key in ("j", "down"):
-            self.selected_index = (self.selected_index + 1) % total
-            self.refresh()
-            event.stop()
-
-        elif key in ("k", "up"):
-            self.selected_index = (self.selected_index - 1) % total
-            self.refresh()
-            event.stop()
-
-        elif key == "enter":
+        key = event.key
+        if key == "enter":
             self._select()
             event.stop()
-
         elif key in ("escape", "q", "Q"):
             self._skip()
             event.stop()
 
-    def _hide(self) -> None:
-        self.remove_class("visible")
-        if self._previous_focus is not None:
-            try:
-                self._previous_focus.focus()
-            except (AttributeError, Exception) as e:
-                logger.debug("Failed to restore focus: %s", e)
-        self._previous_focus = None
-
     def _select(self) -> None:
         if self.selected_index == 0:
-            # "(none)" selected
             self.post_message(self.AgentSelected(None))
         else:
             agent_name = self._agents[self.selected_index - 1]
@@ -106,24 +82,7 @@ class AgentSelectModal(Static, can_focus=True):
         self._hide()
 
     def show(self, agents: List[str], app_ref: Optional[Any] = None) -> None:
-        """Display the modal with available agents.
-
-        Args:
-            agents: List of agent names (from scan_agents).
-            app_ref: Reference to the app for focus management.
-        """
+        """Display the modal with available agents."""
         self._agents = list(agents)
-        self._app_ref = app_ref
-        self._previous_focus = None
-        if app_ref:
-            try:
-                self._previous_focus = app_ref.focused
-            except (AttributeError, Exception) as e:
-                logger.debug("Failed to save focus: %s", e)
-        self.selected_index = 0
-        self.refresh()
-        self.add_class("visible")
-        try:
-            self.focus()
-        except (AttributeError, Exception) as e:
-            logger.debug("Failed to focus modal: %s", e)
+        self._save_focus(app_ref)
+        self._show()

--- a/src/overcode/tui_widgets/instruction_history_modal.py
+++ b/src/overcode/tui_widgets/instruction_history_modal.py
@@ -5,17 +5,15 @@ Shows the last N instructions sent to any agent, allowing the user
 to select one and reinject it into the currently focused agent (#376).
 """
 
-import logging
 import time
 from dataclasses import dataclass, field
 from typing import List, Optional, Any
 
-from textual.widgets import Static
 from textual.message import Message
 from textual import events
 from rich.text import Text
 
-logger = logging.getLogger(__name__)
+from .modal_base import ModalBase
 
 MAX_HISTORY = 10
 
@@ -31,7 +29,7 @@ class HistoryEntry:
     @property
     def preview(self) -> str:
         """Single-line preview, truncated to 60 chars."""
-        oneline = self.text.replace("\n", " ↵ ")
+        oneline = self.text.replace("\n", " \u21b5 ")
         if len(oneline) > 60:
             return oneline[:57] + "..."
         return oneline
@@ -48,7 +46,7 @@ class HistoryEntry:
             return f"{delta // 3600}h ago"
 
 
-class InstructionHistoryModal(Static, can_focus=True):
+class InstructionHistoryModal(ModalBase):
     """Modal showing recent instructions sent to agents.
 
     Navigate with j/k or up/down arrows.
@@ -70,8 +68,6 @@ class InstructionHistoryModal(Static, can_focus=True):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._entries: List[HistoryEntry] = []
-        self.selected_index: int = 0
-        self._previous_focus: Optional[Any] = None
 
     def render(self) -> Text:
         text = Text()
@@ -102,63 +98,33 @@ class InstructionHistoryModal(Static, can_focus=True):
         return text
 
     def on_key(self, event: events.Key) -> None:
-        key = event.key
         total = len(self._entries)
 
         if not total:
-            if key in ("escape", "q", "Q"):
+            if event.key in ("escape", "q", "Q"):
                 self._dismiss()
                 event.stop()
             return
 
-        if key in ("j", "down"):
-            self.selected_index = (self.selected_index + 1) % total
-            self.refresh()
-            event.stop()
+        if self._navigate(event, total):
+            return
 
-        elif key in ("k", "up"):
-            self.selected_index = (self.selected_index - 1) % total
-            self.refresh()
-            event.stop()
-
-        elif key == "enter":
+        key = event.key
+        if key == "enter":
             entry = self._entries[self.selected_index]
             self.post_message(self.ReinjectRequested(entry.text))
             self._dismiss()
             event.stop()
-
         elif key in ("escape", "q", "Q"):
             self._dismiss()
             event.stop()
 
     def _dismiss(self) -> None:
-        self.remove_class("visible")
         self.post_message(self.Cancelled())
-        if self._previous_focus is not None:
-            try:
-                self._previous_focus.focus()
-            except (AttributeError, Exception) as e:
-                logger.debug("Failed to restore focus: %s", e)
-        self._previous_focus = None
+        self._hide()
 
     def show(self, entries: List[HistoryEntry], app_ref: Optional[Any] = None) -> None:
-        """Display the modal with instruction history.
-
-        Args:
-            entries: List of HistoryEntry objects (most recent first).
-            app_ref: Reference to the app for focus management.
-        """
+        """Display the modal with instruction history."""
         self._entries = list(entries)
-        self._previous_focus = None
-        if app_ref:
-            try:
-                self._previous_focus = app_ref.focused
-            except (AttributeError, Exception) as e:
-                logger.debug("Failed to save focus: %s", e)
-        self.selected_index = 0
-        self.refresh()
-        self.add_class("visible")
-        try:
-            self.focus()
-        except (AttributeError, Exception) as e:
-            logger.debug("Failed to focus modal: %s", e)
+        self._save_focus(app_ref)
+        self._show()

--- a/src/overcode/tui_widgets/modal_base.py
+++ b/src/overcode/tui_widgets/modal_base.py
@@ -1,0 +1,78 @@
+"""
+Base class for keyboard-navigable modal dialogs.
+
+Extracts shared show/hide, focus save/restore, and j/k navigation
+patterns common to all 5 modal widgets.
+"""
+
+import logging
+from typing import Optional, Any
+
+from textual.widgets import Static
+from textual import events
+
+logger = logging.getLogger(__name__)
+
+
+class ModalBase(Static, can_focus=True):
+    """Base class for modal dialogs with keyboard navigation.
+
+    Subclasses must implement:
+        - render() -> Text
+        - on_key() for modal-specific key bindings (call super for navigation)
+
+    Provides:
+        - show()/hide with focus save/restore
+        - j/k/up/down navigation with selected_index
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.selected_index: int = 0
+        self._app_ref: Optional[Any] = None
+        self._previous_focus: Optional[Any] = None
+
+    def _save_focus(self, app_ref: Optional[Any]) -> None:
+        """Save current focus for later restoration."""
+        self._app_ref = app_ref
+        self._previous_focus = None
+        if app_ref:
+            try:
+                self._previous_focus = app_ref.focused
+            except (AttributeError, Exception) as e:
+                logger.debug("Failed to save focus: %s", e)
+
+    def _show(self) -> None:
+        """Common show logic: reset index, refresh, add visible class, focus."""
+        self.selected_index = 0
+        self.refresh()
+        self.add_class("visible")
+        try:
+            self.focus()
+        except (AttributeError, Exception) as e:
+            logger.debug("Failed to focus modal: %s", e)
+
+    def _hide(self) -> None:
+        """Hide the modal and restore previous focus."""
+        self.remove_class("visible")
+        if self._previous_focus is not None:
+            try:
+                self._previous_focus.focus()
+            except (AttributeError, Exception) as e:
+                logger.debug("Failed to restore focus: %s", e)
+        self._previous_focus = None
+
+    def _navigate(self, event: events.Key, total: int) -> bool:
+        """Handle j/k/up/down navigation. Returns True if handled."""
+        key = event.key
+        if key in ("j", "down"):
+            self.selected_index = (self.selected_index + 1) % total
+            self.refresh()
+            event.stop()
+            return True
+        elif key in ("k", "up"):
+            self.selected_index = (self.selected_index - 1) % total
+            self.refresh()
+            event.stop()
+            return True
+        return False

--- a/src/overcode/tui_widgets/new_agent_defaults_modal.py
+++ b/src/overcode/tui_widgets/new_agent_defaults_modal.py
@@ -5,15 +5,13 @@ Keyboard-navigable checkbox list to toggle bypass_permissions and agent_teams.
 Persists to ~/.overcode/config.yaml via config helpers.
 """
 
-import logging
 from typing import Optional, Any
 
-from textual.widgets import Static
 from textual.message import Message
 from textual import events
 from rich.text import Text
 
-logger = logging.getLogger(__name__)
+from .modal_base import ModalBase
 
 
 # (label, dict key)
@@ -23,7 +21,7 @@ _OPTIONS = [
 ]
 
 
-class NewAgentDefaultsModal(Static, can_focus=True):
+class NewAgentDefaultsModal(ModalBase):
     """Modal dialog for configuring new-agent defaults.
 
     Navigate with j/k or up/down arrows, toggle with space/enter.
@@ -44,9 +42,6 @@ class NewAgentDefaultsModal(Static, can_focus=True):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.defaults: dict = {"bypass_permissions": False, "agent_teams": False}
-        self.selected_index: int = 0
-        self._app_ref: Optional[Any] = None
-        self._previous_focus: Optional[Any] = None
 
     def render(self) -> Text:
         text = Text()
@@ -73,40 +68,21 @@ class NewAgentDefaultsModal(Static, can_focus=True):
         return text
 
     def on_key(self, event: events.Key) -> None:
+        if self._navigate(event, len(_OPTIONS)):
+            return
+
         key = event.key
-
-        if key in ("j", "down"):
-            self.selected_index = (self.selected_index + 1) % len(_OPTIONS)
-            self.refresh()
-            event.stop()
-
-        elif key in ("k", "up"):
-            self.selected_index = (self.selected_index - 1) % len(_OPTIONS)
-            self.refresh()
-            event.stop()
-
-        elif key in ("space", "enter"):
+        if key in ("space", "enter"):
             _, dict_key = _OPTIONS[self.selected_index]
             self.defaults[dict_key] = not self.defaults.get(dict_key, False)
             self.refresh()
             event.stop()
-
         elif key in ("a", "A"):
             self._apply()
             event.stop()
-
         elif key in ("escape", "q", "Q"):
             self._cancel()
             event.stop()
-
-    def _hide(self) -> None:
-        self.remove_class("visible")
-        if self._previous_focus is not None:
-            try:
-                self._previous_focus.focus()
-            except (AttributeError, Exception) as e:
-                logger.debug("Failed to restore focus: %s", e)
-        self._previous_focus = None
 
     def _apply(self) -> None:
         self.post_message(self.DefaultsChanged(dict(self.defaults)))
@@ -118,17 +94,5 @@ class NewAgentDefaultsModal(Static, can_focus=True):
 
     def show(self, defaults: dict, app_ref: Optional[Any] = None) -> None:
         self.defaults = dict(defaults)
-        self._app_ref = app_ref
-        self._previous_focus = None
-        if app_ref:
-            try:
-                self._previous_focus = app_ref.focused
-            except (AttributeError, Exception) as e:
-                logger.debug("Failed to save focus: %s", e)
-        self.selected_index = 0
-        self.refresh()
-        self.add_class("visible")
-        try:
-            self.focus()
-        except (AttributeError, Exception) as e:
-            logger.debug("Failed to focus modal: %s", e)
+        self._save_focus(app_ref)
+        self._show()

--- a/src/overcode/tui_widgets/session_summary.py
+++ b/src/overcode/tui_widgets/session_summary.py
@@ -145,27 +145,46 @@ class SessionSummary(Static, can_focus=True):
         self.apply_status_no_refresh(status, activity, content, claude_stats, git_diff)
         self.refresh()
 
-    def apply_status_no_refresh(self, status: str, activity: str, content: str, claude_stats: Optional[ClaudeSessionStats] = None, git_diff_stats: Optional[tuple] = None) -> None:
+    def apply_status_no_refresh(self, status: str, activity: str, content: str, claude_stats: Optional[ClaudeSessionStats] = None, git_diff_stats: Optional[tuple] = None) -> bool:
         """Apply pre-fetched status data without triggering refresh.
 
         Used for batched updates where the caller will refresh once at the end.
         All data including claude_stats should be pre-fetched in background thread.
+
+        Returns True if any data actually changed (caller should refresh).
         """
-        self.current_activity = activity
+        changed = False
+
+        if self.current_activity != activity:
+            self.current_activity = activity
+            changed = True
 
         # Use pane content from detect_status (already fetched)
         if content:
             # Keep all lines including blanks for proper formatting, just strip trailing blanks
             lines = content.rstrip().split('\n')
-            self.pane_content = lines if lines else []
+            new_pane = lines if lines else []
             # Pure extraction — results stored as widget vars, never on session
             extracted = extract_from_pane(content)
-            self.background_bash_count = extracted.background_bash_count
-            self.live_subagent_count = extracted.live_subagent_count
+            if self.pane_content != new_pane:
+                self.pane_content = new_pane
+                changed = True
+            if self.background_bash_count != extracted.background_bash_count:
+                self.background_bash_count = extracted.background_bash_count
+                changed = True
+            if self.live_subagent_count != extracted.live_subagent_count:
+                self.live_subagent_count = extracted.live_subagent_count
+                changed = True
         else:
-            self.pane_content = []
-            self.background_bash_count = 0
-            self.live_subagent_count = 0
+            if self.pane_content:
+                self.pane_content = []
+                changed = True
+            if self.background_bash_count != 0:
+                self.background_bash_count = 0
+                changed = True
+            if self.live_subagent_count != 0:
+                self.live_subagent_count = 0
+                changed = True
 
         # Update detected status for display
         # NOTE: Time tracking removed - Monitor Daemon is the single source of truth
@@ -183,17 +202,24 @@ class SessionSummary(Static, can_focus=True):
         # (e.g. running ↔ running_heartbeat) don't reset the timer.
         if get_status_color(new_status) != get_status_color(self._last_known_status):
             self._status_changed_at = datetime.now()
+            changed = True
         self._last_known_status = new_status
 
-        self.detected_status = new_status
+        if self.detected_status != new_status:
+            self.detected_status = new_status
+            changed = True
 
         # Use pre-fetched claude stats (no file I/O on main thread)
         if claude_stats is not None:
             self.claude_stats = claude_stats
+            changed = True
 
         # Use pre-fetched git diff stats
         if git_diff_stats is not None:
             self.git_diff_stats = git_diff_stats
+            changed = True
+
+        return changed
 
     def watch_summary_detail(self, summary_detail: str) -> None:
         """Called when summary_detail changes"""

--- a/src/overcode/tui_widgets/sister_selection_modal.py
+++ b/src/overcode/tui_widgets/sister_selection_modal.py
@@ -5,18 +5,16 @@ Allows toggling visibility of each configured sister instance.
 Disabled sisters' agents are hidden from the agent list.
 """
 
-import logging
 from typing import Dict, List, Optional, Any, Set
 
-from textual.widgets import Static
 from textual.message import Message
 from textual import events
 from rich.text import Text
 
-logger = logging.getLogger(__name__)
+from .modal_base import ModalBase
 
 
-class SisterSelectionModal(Static, can_focus=True):
+class SisterSelectionModal(ModalBase):
     """Modal dialog for toggling sister visibility.
 
     Navigate with j/k, toggle with space/enter.
@@ -39,9 +37,6 @@ class SisterSelectionModal(Static, can_focus=True):
         self._sisters: List[Dict[str, str]] = []  # [{name, url}, ...]
         self._disabled: Set[str] = set()
         self._original_disabled: Set[str] = set()
-        self.selected_index: int = 0
-        self._app_ref: Optional[Any] = None
-        self._previous_focus: Optional[Any] = None
 
     def render(self) -> Text:
         text = Text()
@@ -79,25 +74,16 @@ class SisterSelectionModal(Static, can_focus=True):
                 event.stop()
             return
 
-        if key in ("j", "down"):
-            self.selected_index = (self.selected_index + 1) % len(self._sisters)
-            self.refresh()
-            event.stop()
+        if self._navigate(event, len(self._sisters)):
+            return
 
-        elif key in ("k", "up"):
-            self.selected_index = (self.selected_index - 1) % len(self._sisters)
-            self.refresh()
-            event.stop()
-
-        elif key in ("space", "enter"):
+        if key in ("space", "enter"):
             self._toggle_current()
             self.refresh()
             event.stop()
-
         elif key in ("a", "A"):
             self._apply()
             event.stop()
-
         elif key in ("escape", "q", "Q"):
             self._cancel()
             event.stop()
@@ -111,15 +97,6 @@ class SisterSelectionModal(Static, can_focus=True):
         else:
             self._disabled.add(name)
 
-    def _hide(self) -> None:
-        self.remove_class("visible")
-        if self._previous_focus is not None:
-            try:
-                self._previous_focus.focus()
-            except (AttributeError, Exception) as e:
-                logger.debug("Failed to restore focus: %s", e)
-        self._previous_focus = None
-
     def _apply(self) -> None:
         self.post_message(self.SelectionChanged(set(self._disabled)))
         self._hide()
@@ -131,27 +108,9 @@ class SisterSelectionModal(Static, can_focus=True):
 
     def show(self, sisters: List[Dict[str, str]], disabled: Set[str],
              app_ref: Optional[Any] = None) -> None:
-        """Display the modal with configured sisters.
-
-        Args:
-            sisters: List of dicts with 'name' and 'url' keys.
-            disabled: Set of sister names currently disabled.
-            app_ref: Reference to the app for focus management.
-        """
+        """Display the modal with configured sisters."""
         self._sisters = list(sisters)
         self._disabled = set(disabled)
         self._original_disabled = set(disabled)
-        self._app_ref = app_ref
-        self._previous_focus = None
-        if app_ref:
-            try:
-                self._previous_focus = app_ref.focused
-            except (AttributeError, Exception) as e:
-                logger.debug("Failed to save focus: %s", e)
-        self.selected_index = 0
-        self.refresh()
-        self.add_class("visible")
-        try:
-            self.focus()
-        except (AttributeError, Exception) as e:
-            logger.debug("Failed to focus modal: %s", e)
+        self._save_focus(app_ref)
+        self._show()

--- a/src/overcode/tui_widgets/summary_config_modal.py
+++ b/src/overcode/tui_widgets/summary_config_modal.py
@@ -9,7 +9,6 @@ Updates live summary lines as you toggle groups/columns.
 import logging
 from typing import Dict, List, Optional, Any, Tuple
 
-from textual.widgets import Static
 from textual.message import Message
 from textual import events
 from rich.text import Text
@@ -18,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 from ..summary_groups import SUMMARY_GROUPS, SUMMARY_GROUPS_BY_ID
 from ..summary_columns import SUMMARY_COLUMNS, SummaryColumn, resolve_column_visible
+from .modal_base import ModalBase
 
 
 # Build group -> columns mapping
@@ -28,7 +28,7 @@ def _columns_by_group() -> Dict[str, List[SummaryColumn]]:
     return result
 
 
-class SummaryConfigModal(Static, can_focus=True):
+class SummaryConfigModal(ModalBase):
     """Modal dialog for configuring per-level column visibility.
 
     Groups with individual columns always shown.
@@ -53,8 +53,6 @@ class SummaryConfigModal(Static, can_focus=True):
         self.overrides: Dict[str, bool] = {}
         self.original_overrides: Dict[str, bool] = {}
         self.cursor_pos: int = 0
-        self._app_ref: Optional[Any] = None
-        self._previous_focus: Optional[Any] = None
         self._cols_by_group = _columns_by_group()
         self._flat_rows: List[Tuple[str, str]] = []
         self._rebuild_flat_rows()
@@ -246,16 +244,6 @@ class SummaryConfigModal(Static, can_focus=True):
             current = self._col_effective(row_id)
             self.overrides[row_id] = not current
 
-    def _hide(self) -> None:
-        """Hide the modal and restore focus."""
-        self.remove_class("visible")
-        if self._previous_focus is not None:
-            try:
-                self._previous_focus.focus()
-            except (AttributeError, Exception) as e:
-                logger.debug("Failed to restore focus: %s", e)
-        self._previous_focus = None
-
     def _apply_config(self) -> None:
         """Apply the current configuration."""
         # Clean up overrides that match defaults (no need to store them)
@@ -278,15 +266,9 @@ class SummaryConfigModal(Static, can_focus=True):
         self.level = level
         self.overrides = dict(overrides)
         self.original_overrides = dict(overrides)
-        self._app_ref = app_ref
-        self._previous_focus = None
-        if app_ref:
-            try:
-                self._previous_focus = app_ref.focused
-            except (AttributeError, Exception) as e:
-                logger.debug("Failed to save focus: %s", e)
         self.cursor_pos = 0
         self._rebuild_flat_rows()
+        self._save_focus(app_ref)
         self.refresh()
         self.add_class("visible")
         try:

--- a/src/overcode/web_control_api.py
+++ b/src/overcode/web_control_api.py
@@ -130,22 +130,18 @@ def kill_agent(tmux_session: str, name: str, cascade: bool = True) -> dict:
 
 def restart_agent(tmux_session: str, name: str) -> dict:
     """Ctrl-C + relaunch with same permissions."""
-    import os
+    from .launcher import ClaudeLauncher
     from .tmux_manager import TmuxManager
     from .session_manager import SessionManager
 
     sm = SessionManager()
     session = _get_session_or_error(sm, name)
 
-    # Build the claude command based on permissiveness mode
-    claude_command = os.environ.get("CLAUDE_COMMAND", "claude")
-    cmd_parts = [claude_command]
-
-    if session.permissiveness_mode == "bypass":
-        cmd_parts.append("--dangerously-skip-permissions")
-    elif session.permissiveness_mode == "permissive":
-        cmd_parts.extend(["--permission-mode", "dontAsk"])
-
+    # Use shared command builder to get the full claude command with all flags
+    launcher = ClaudeLauncher(tmux_session=tmux_session, session_manager=sm)
+    cmd_parts = launcher._build_claude_command(
+        permissiveness_mode=session.permissiveness_mode,
+    )
     cmd_str = " ".join(cmd_parts)
 
     tmux = TmuxManager(tmux_session)
@@ -482,23 +478,8 @@ def transport_all(tmux_session: str) -> dict:
     if not active:
         raise ControlError("No active agents to transport", status=409)
 
-    handover_instruction = (
-        "Please prepare for handover. Follow these steps in order:\n\n"
-        "1. Check your current branch with `git branch --show-current`\n"
-        "   - If on main or master, create and switch to a new branch:\n"
-        "     `git checkout -b handover/<brief-task-description>`\n"
-        "   - Never push directly to main/master\n\n"
-        "2. Commit all your current changes with a descriptive commit message\n\n"
-        "3. Push to your branch: `git push -u origin <branch-name>`\n\n"
-        "4. Check if a PR exists: `gh pr list --head $(git branch --show-current)`\n"
-        "   - If no PR exists, create a draft PR:\n"
-        "     `gh pr create --draft --title '<brief title>' --body 'WIP'`\n\n"
-        "5. Post a handover comment on the PR using `gh pr comment` with:\n"
-        "   - What you've accomplished\n"
-        "   - Current state of the work\n"
-        "   - Any pending tasks or next steps\n"
-        "   - Known issues or blockers"
-    )
+    from .standing_instructions import HANDOVER_INSTRUCTION
+    handover_instruction = HANDOVER_INSTRUCTION
 
     success_count = 0
     for session in active:

--- a/src/overcode/web_server_runner.py
+++ b/src/overcode/web_server_runner.py
@@ -85,8 +85,9 @@ def main():
         log(session, "Server created, starting serve_forever()")
 
         # Redirect stdout/stderr AFTER setup is complete
-        sys.stdout = open(os.devnull, 'w')
-        sys.stderr = open(os.devnull, 'w')
+        _devnull = open(os.devnull, 'w')
+        sys.stdout = _devnull
+        sys.stderr = _devnull
 
         server.serve_forever()
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,29 +8,32 @@ import os
 import pytest
 import tempfile
 import shutil
+from pathlib import Path
 
 from tests.daemon_test_utils import stop_daemons_in_state_dir
 
 
+# Test classes that actually mount Textual apps or start daemons and need
+# an isolated OVERCODE_STATE_DIR with daemon cleanup on teardown.
+_CLASSES_NEEDING_ISOLATION = frozenset({
+    "TestSupervisorTUIPilot",
+    "TestHelpOverlayPilot",
+    "TestCommandBarWidget",
+    "TestCommandBarIntegration",
+    "TestCommandBarWithSessions",
+    "TestUniqueAgentName",
+})
+
+
 @pytest.fixture(autouse=True)
 def isolated_state_dir(request):
-    """Automatically isolate state directory for tests that use TUI or daemons.
+    """Isolate state directory for tests that mount TUI apps or start daemons.
 
-    This fixture is auto-used but only activates for tests that might start
-    daemons (e.g., TUI tests). It sets OVERCODE_STATE_DIR to a temp directory
-    so any daemons started during tests don't pollute the user's ~/.overcode.
-
-    The fixture checks if the test file contains certain markers that indicate
-    it might start daemons.
+    Only activates for test classes listed in _CLASSES_NEEDING_ISOLATION.
+    Pure function tests in the same files are not affected.
     """
-    # Only activate for tests that might start daemons
-    test_file = str(request.fspath)
-    needs_isolation = any(marker in test_file for marker in [
-        "test_tui.py",
-        "test_command_bar.py",
-    ])
-
-    if not needs_isolation:
+    cls_name = request.node.cls.__name__ if request.node.cls else ""
+    if cls_name not in _CLASSES_NEEDING_ISOLATION:
         yield
         return
 
@@ -46,15 +49,15 @@ def isolated_state_dir(request):
     try:
         yield state_dir
     finally:
-        # Stop any daemons that were started during the test
-        stop_daemons_in_state_dir(state_dir)
+        # Only run expensive daemon cleanup if PID files were actually created
+        state_path = Path(state_dir)
+        has_pid_files = any(state_path.rglob("*.pid")) if state_path.exists() else False
 
-        # Wait a bit for daemons to fully exit
-        import time
-        time.sleep(0.5)
-
-        # Retry cleanup - daemon might have written PID file after first attempt
-        stop_daemons_in_state_dir(state_dir)
+        if has_pid_files:
+            stop_daemons_in_state_dir(state_dir)
+            import time
+            time.sleep(0.3)
+            stop_daemons_in_state_dir(state_dir)
 
         # Remove temp state directory
         shutil.rmtree(state_dir, ignore_errors=True)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -9,6 +9,14 @@ from pathlib import Path
 from overcode import config
 
 
+@pytest.fixture(autouse=True)
+def _clear_config_cache():
+    """Clear config cache before each test to prevent cross-test contamination."""
+    config._clear_config_cache()
+    yield
+    config._clear_config_cache()
+
+
 class TestLoadConfig:
     """Test config loading functionality."""
 

--- a/tests/unit/test_status_timeline.py
+++ b/tests/unit/test_status_timeline.py
@@ -14,10 +14,12 @@ from unittest.mock import MagicMock, patch, PropertyMock
 # Helper to build a bare StatusTimeline without the Textual app
 # ---------------------------------------------------------------------------
 
-def _make_mock_session(name="agent-1"):
+def _make_mock_session(name="agent-1", is_remote=False, source_host=""):
     """Create a minimal mock session with a name attribute."""
     mock = MagicMock()
     mock.name = name
+    mock.is_remote = is_remote
+    mock.source_host = source_host
     return mock
 
 

--- a/tests/unit/test_web_server.py
+++ b/tests/unit/test_web_server.py
@@ -1212,7 +1212,7 @@ class TestDispatchControl:
 
         mock_fn.assert_called_once_with(
             "test-session", directory="/tmp", name="new-agent",
-            prompt="test", permissions="normal"
+            prompt="test", permissions="normal", provider="web"
         )
 
     def test_post_sleep_agent(self):


### PR DESCRIPTION
## Summary
- **Performance (#372):** Config TTL+mtime cache, column width dirty flag, presence history mtime cache, terminated sessions GC, widget change tracking
- **Refactoring (#371):** Extract ModalBase for 5 modals, unify summarizer methods, DRY command construction + handover instruction, fix file handle leak
- **Tests:** Fix 4 pre-existing failures, target isolated_state_dir fixture to Pilot tests only (190s → 85s), clean up pytest.ini defaults

## Test plan
- [x] Full unit suite: 3253 passed, 11 skipped, 0 failed (85s)
- [x] All imports verified
- [ ] CI/CD green

🤖 Generated with [Claude Code](https://claude.com/claude-code)