### PR TITLE
Inject hooks/permissions via --settings at launch time

### DIFF
--- a/src/overcode/cli/hooks.py
+++ b/src/overcode/cli/hooks.py
@@ -1,5 +1,5 @@
 """
-Hooks commands: install, uninstall, status.
+Hooks commands: install (deprecated), uninstall, status.
 """
 
 from typing import Annotated
@@ -10,51 +10,27 @@ from rich import print as rprint
 from ._shared import hooks_app
 
 
-@hooks_app.command("install")
+DEPRECATION_NOTE = (
+    "[yellow]Note:[/yellow] Manual hook installation is deprecated.\n"
+    "  Hooks are now injected automatically when agents are launched via 'overcode launch'.\n"
+    "  Use 'overcode hooks uninstall' to remove legacy hooks from your settings."
+)
+
+
+@hooks_app.command("install", deprecated=True)
 def hooks_install(
     project: Annotated[
         bool,
         typer.Option("--project", "-p", help="Install to project-level .claude/settings.json instead of user-level"),
     ] = False,
 ):
-    """Install all overcode hooks into Claude Code settings.
+    """[Deprecated] Install overcode hooks into Claude Code settings.
 
-    Installs hooks for: UserPromptSubmit, PostToolUse, Stop,
-    PermissionRequest, SessionEnd. All use the unified 'overcode hook-handler'.
+    Hooks are now injected automatically at launch time via --settings.
+    This command is no longer needed for overcode-launched agents.
     """
-    from ..claude_config import ClaudeConfigEditor
-    from ..hook_handler import OVERCODE_HOOKS
-
-    if project:
-        editor = ClaudeConfigEditor.project_level()
-        level = "project"
-    else:
-        editor = ClaudeConfigEditor.user_level()
-        level = "user"
-
-    try:
-        editor.load()
-    except ValueError as e:
-        rprint(f"[red]Error:[/red] {e}")
-        raise typer.Exit(1)
-
-    # Install all overcode hooks (idempotent)
-    installed = 0
-    already = 0
-    for event, command in OVERCODE_HOOKS:
-        if editor.add_hook(event, command):
-            installed += 1
-        else:
-            already += 1
-
-    if installed > 0:
-        events = ", ".join(event for event, _ in OVERCODE_HOOKS)
-        rprint(f"[green]\u2713[/green] Installed {installed} hook(s) in {level} settings")
-        rprint(f"  [dim]{editor.path}[/dim]")
-        rprint(f"\n  Events: {events}")
-        rprint("  All hooks run 'overcode hook-handler' (reads event from stdin).")
-    elif already == len(OVERCODE_HOOKS):
-        rprint(f"[green]\u2713[/green] All {already} hooks already installed in {level} settings")
+    rprint(DEPRECATION_NOTE)
+    raise typer.Exit(0)
 
 
 @hooks_app.command("uninstall")
@@ -97,6 +73,8 @@ def hooks_status():
     """Show which overcode hooks are installed."""
     from ..claude_config import ClaudeConfigEditor
     from ..hook_handler import OVERCODE_HOOKS
+
+    rprint(f"\n{DEPRECATION_NOTE}\n")
 
     for level_name, editor in [
         ("User-level", ClaudeConfigEditor.user_level()),

--- a/src/overcode/cli/perms.py
+++ b/src/overcode/cli/perms.py
@@ -1,5 +1,5 @@
 """
-Permissions commands: install, uninstall, status.
+Permissions commands: install (deprecated), uninstall, status.
 """
 
 from typing import Annotated
@@ -25,7 +25,14 @@ OVERCODE_PUNCHY_PERMS = [
 ]
 
 
-@perms_app.command("install")
+DEPRECATION_NOTE = (
+    "[yellow]Note:[/yellow] Manual permission installation is deprecated.\n"
+    "  Permissions are now injected automatically when agents are launched via 'overcode launch'.\n"
+    "  Use 'overcode perms uninstall' to remove legacy permissions from your settings."
+)
+
+
+@perms_app.command("install", deprecated=True)
 def perms_install(
     project: Annotated[
         bool,
@@ -36,47 +43,13 @@ def perms_install(
         typer.Option("--all", help="Include punchy permissions (launch, send, instruct)"),
     ] = False,
 ):
-    """Install overcode tool permissions into Claude Code settings.
+    """[Deprecated] Install overcode permissions into Claude Code settings.
 
-    By default installs safe (read-only) permissions. Use --all to also
-    include punchy permissions that can spawn or control agents.
-
-    Safe: report, show, list, follow, kill, budget
-    Punchy (--all): launch, send, instruct
+    Permissions are now injected automatically at launch time via --settings.
+    This command is no longer needed for overcode-launched agents.
     """
-    from ..claude_config import ClaudeConfigEditor
-
-    if project:
-        editor = ClaudeConfigEditor.project_level()
-        level = "project"
-    else:
-        editor = ClaudeConfigEditor.user_level()
-        level = "user"
-
-    try:
-        editor.load()
-    except ValueError as e:
-        rprint(f"[red]Error:[/red] {e}")
-        raise typer.Exit(1)
-
-    perms = OVERCODE_SAFE_PERMS + (OVERCODE_PUNCHY_PERMS if all_perms else [])
-
-    installed = 0
-    already = 0
-    for perm in perms:
-        if editor.add_permission(perm):
-            installed += 1
-        else:
-            already += 1
-
-    if installed > 0:
-        tier = "safe + punchy" if all_perms else "safe"
-        rprint(f"[green]\u2713[/green] Installed {installed} permission(s) in {level} settings ({tier})")
-        rprint(f"  [dim]{editor.path}[/dim]")
-        for perm in perms:
-            rprint(f"  {perm}")
-    elif already == len(perms):
-        rprint(f"[green]\u2713[/green] All {already} permissions already installed in {level} settings")
+    rprint(DEPRECATION_NOTE)
+    raise typer.Exit(0)
 
 
 @perms_app.command("uninstall")
@@ -118,6 +91,8 @@ def perms_uninstall(
 def perms_status():
     """Show which overcode permissions are installed."""
     from ..claude_config import ClaudeConfigEditor
+
+    rprint(f"\n{DEPRECATION_NOTE}\n")
 
     all_perms = OVERCODE_SAFE_PERMS + OVERCODE_PUNCHY_PERMS
 

--- a/src/overcode/launcher.py
+++ b/src/overcode/launcher.py
@@ -7,10 +7,13 @@ Claude starts, not as CLI arguments.
 
 """
 
-import time
+import json
+import shlex
+import shutil
 import subprocess
 import os
-import shlex
+import sys
+import time
 import uuid
 from pathlib import Path
 from typing import List, Optional
@@ -42,6 +45,47 @@ def validate_session_name(name: str) -> None:
         raise InvalidSessionNameError(name, "name cannot be empty")
     if not SESSION_NAME_PATTERN.match(name):
         raise InvalidSessionNameError(name)
+
+def _resolve_overcode_bin() -> str:
+    """Resolve absolute path to the overcode binary.
+
+    Tries shutil.which first (covers global/pipx installs), then falls
+    back to invoking via the current Python interpreter (covers uv run,
+    venv-only installs, etc.).
+    """
+    which = shutil.which("overcode")
+    if which:
+        return which
+    return f"{sys.executable} -m overcode.cli"
+
+
+def _build_launch_settings(overcode_bin: str, include_punchy_perms: bool = False) -> dict:
+    """Build the --settings JSON for overcode-launched agents.
+
+    Includes all overcode hooks (with absolute-path commands) and
+    permissions so agents don't depend on user-level settings.json
+    containing these entries.
+    """
+    from .hook_handler import OVERCODE_HOOKS
+    from .cli.perms import OVERCODE_SAFE_PERMS, OVERCODE_PUNCHY_PERMS
+
+    # Build hooks dict: event -> [matcher group]
+    hooks: dict[str, list] = {}
+    for event, _bare_command in OVERCODE_HOOKS:
+        hooks.setdefault(event, []).append({
+            "matcher": "",
+            "hooks": [{"type": "command", "command": f"{overcode_bin} hook-handler"}],
+        })
+
+    perms = list(OVERCODE_SAFE_PERMS)
+    if include_punchy_perms:
+        perms.extend(OVERCODE_PUNCHY_PERMS)
+
+    return {
+        "hooks": hooks,
+        "permissions": {"allow": perms},
+    }
+
 
 class ClaudeLauncher:
     """Launches interactive Claude Code sessions in tmux windows.
@@ -82,6 +126,7 @@ class ClaudeLauncher:
         fork: bool = False,
         claude_session_id: Optional[str] = None,
         model: Optional[str] = None,
+        include_punchy_perms: bool = False,
     ) -> List[str]:
         """Construct the claude CLI argument list.
 
@@ -107,6 +152,12 @@ class ClaudeLauncher:
         # this agent without needing PID-based discovery (#373).
         if claude_session_id and not resume_session_id:
             cmd.extend(["--session-id", claude_session_id])
+
+        # Inject overcode hooks and permissions via --settings so launched
+        # agents don't depend on user-level settings.json (#435).
+        overcode_bin = _resolve_overcode_bin()
+        settings = _build_launch_settings(overcode_bin, include_punchy_perms=include_punchy_perms)
+        cmd.extend(["--settings", json.dumps(settings)])
 
         # Permission flags — from explicit args or inherited mode
         if dangerously_skip_permissions or permissiveness_mode == "bypass":

--- a/src/overcode/tui_actions/session.py
+++ b/src/overcode/tui_actions/session.py
@@ -312,7 +312,7 @@ class SessionActionsMixin:
             from ..claude_config import ClaudeConfigEditor
             if not ClaudeConfigEditor.are_overcode_hooks_installed():
                 self.notify(
-                    "Hooks not installed — run 'overcode hooks install' first",
+                    "No legacy hooks found in settings — launched agents inject hooks automatically",
                     severity="error",
                 )
                 return

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1461,61 +1461,13 @@ class TestShowExtended:
 
 
 class TestHooksInstallCommand:
-    """Test hooks install command."""
+    """Test hooks install command (deprecated)."""
 
-    def test_hooks_install_user_level(self):
-        """Hooks install at user level."""
-        with patch('overcode.claude_config.ClaudeConfigEditor') as mock_editor_cls:
-            mock_editor = MagicMock()
-            mock_editor.load.return_value = {}
-            mock_editor.add_hook.return_value = True
-            mock_editor.path = Path("/tmp/.claude/settings.json")
-            mock_editor_cls.user_level.return_value = mock_editor
-
-            with patch('overcode.hook_handler.OVERCODE_HOOKS', [("TestEvent", "test-cmd")]):
-                result = runner.invoke(app, ["hooks", "install"])
-                assert result.exit_code == 0
-                assert "Installed 1 hook" in result.output
-
-    def test_hooks_install_project_level(self):
-        """Hooks install at project level."""
-        with patch('overcode.claude_config.ClaudeConfigEditor') as mock_editor_cls:
-            mock_editor = MagicMock()
-            mock_editor.load.return_value = {}
-            mock_editor.add_hook.return_value = True
-            mock_editor.path = Path("/tmp/.claude/settings.json")
-            mock_editor_cls.project_level.return_value = mock_editor
-
-            with patch('overcode.hook_handler.OVERCODE_HOOKS', [("TestEvent", "test-cmd")]):
-                result = runner.invoke(app, ["hooks", "install", "--project"])
-                assert result.exit_code == 0
-                assert "project" in result.output
-
-    def test_hooks_install_already_installed(self):
-        """Hooks install when all already installed."""
-        with patch('overcode.claude_config.ClaudeConfigEditor') as mock_editor_cls:
-            mock_editor = MagicMock()
-            mock_editor.load.return_value = {}
-            mock_editor.add_hook.return_value = False
-            mock_editor.path = Path("/tmp/.claude/settings.json")
-            mock_editor_cls.user_level.return_value = mock_editor
-
-            with patch('overcode.hook_handler.OVERCODE_HOOKS', [("TestEvent", "test-cmd")]):
-                result = runner.invoke(app, ["hooks", "install"])
-                assert result.exit_code == 0
-                assert "already installed" in result.output
-
-    def test_hooks_install_invalid_json(self):
-        """Hooks install handles invalid JSON."""
-        with patch('overcode.claude_config.ClaudeConfigEditor') as mock_editor_cls:
-            mock_editor = MagicMock()
-            mock_editor.load.side_effect = ValueError("Invalid JSON")
-            mock_editor.path = Path("/tmp/.claude/settings.json")
-            mock_editor_cls.user_level.return_value = mock_editor
-
-            result = runner.invoke(app, ["hooks", "install"])
-            assert result.exit_code == 1
-            assert "Invalid JSON" in result.output
+    def test_hooks_install_shows_deprecation(self):
+        """Hooks install shows deprecation notice and exits."""
+        result = runner.invoke(app, ["hooks", "install"])
+        assert result.exit_code == 0
+        assert "deprecated" in result.output.lower()
 
 
 class TestHooksUninstallCommand:
@@ -1731,57 +1683,13 @@ class TestSkillsStatusCommand:
 
 
 class TestPermsInstallCommand:
-    """Test perms install command."""
+    """Test perms install command (deprecated)."""
 
-    def test_perms_install_safe(self):
-        """Perms install adds safe permissions."""
-        with patch('overcode.claude_config.ClaudeConfigEditor') as mock_editor_cls:
-            mock_editor = MagicMock()
-            mock_editor.load.return_value = {}
-            mock_editor.add_permission.return_value = True
-            mock_editor.path = Path("/tmp/.claude/settings.json")
-            mock_editor_cls.user_level.return_value = mock_editor
-
-            result = runner.invoke(app, ["perms", "install"])
-            assert result.exit_code == 0
-            assert "Installed" in result.output
-            assert "safe" in result.output
-
-    def test_perms_install_all(self):
-        """Perms install --all adds safe + punchy permissions."""
-        with patch('overcode.claude_config.ClaudeConfigEditor') as mock_editor_cls:
-            mock_editor = MagicMock()
-            mock_editor.load.return_value = {}
-            mock_editor.add_permission.return_value = True
-            mock_editor.path = Path("/tmp/.claude/settings.json")
-            mock_editor_cls.user_level.return_value = mock_editor
-
-            result = runner.invoke(app, ["perms", "install", "--all"])
-            assert result.exit_code == 0
-            assert "punchy" in result.output
-
-    def test_perms_install_already(self):
-        """Perms install when all already installed."""
-        with patch('overcode.claude_config.ClaudeConfigEditor') as mock_editor_cls:
-            mock_editor = MagicMock()
-            mock_editor.load.return_value = {}
-            mock_editor.add_permission.return_value = False
-            mock_editor.path = Path("/tmp/.claude/settings.json")
-            mock_editor_cls.user_level.return_value = mock_editor
-
-            result = runner.invoke(app, ["perms", "install"])
-            assert result.exit_code == 0
-            assert "already installed" in result.output
-
-    def test_perms_install_invalid_json(self):
-        """Perms install handles invalid JSON."""
-        with patch('overcode.claude_config.ClaudeConfigEditor') as mock_editor_cls:
-            mock_editor = MagicMock()
-            mock_editor.load.side_effect = ValueError("bad json")
-            mock_editor_cls.user_level.return_value = mock_editor
-
-            result = runner.invoke(app, ["perms", "install"])
-            assert result.exit_code == 1
+    def test_perms_install_shows_deprecation(self):
+        """Perms install shows deprecation notice and exits."""
+        result = runner.invoke(app, ["perms", "install"])
+        assert result.exit_code == 0
+        assert "deprecated" in result.output.lower()
 
 
 class TestPermsUninstallCommand:

--- a/tests/unit/test_hooks_cli.py
+++ b/tests/unit/test_hooks_cli.py
@@ -1,4 +1,4 @@
-"""Tests for the hooks CLI commands (install, uninstall, status)."""
+"""Tests for the hooks CLI commands (install [deprecated], uninstall, status)."""
 
 import json
 from pathlib import Path
@@ -13,80 +13,42 @@ from overcode.hook_handler import OVERCODE_HOOKS
 runner = CliRunner()
 
 
+def _write_settings_with_hooks(settings_path: Path) -> None:
+    """Manually write a settings.json with all overcode hooks installed.
+
+    Used by uninstall/status tests since the install command is deprecated.
+    """
+    hooks = {}
+    for event, command in OVERCODE_HOOKS:
+        hooks.setdefault(event, []).append({
+            "matcher": "",
+            "hooks": [{"type": "command", "command": command}],
+        })
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps({"hooks": hooks}))
+
+
 class TestHooksInstall:
+    """Install is deprecated — just prints a notice."""
 
-    def test_installs_all_hooks(self, tmp_path, monkeypatch):
+    def test_shows_deprecation(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
         result = runner.invoke(app, ["hooks", "install"])
         assert result.exit_code == 0
-        assert "Installed" in result.output
+        assert "deprecated" in result.output.lower()
 
-        f = tmp_path / ".claude" / "settings.json"
-        assert f.exists()
-        data = json.loads(f.read_text())
-        for event, command in OVERCODE_HOOKS:
-            found = False
-            for entry in data["hooks"].get(event, []):
-                for hook in entry.get("hooks", []):
-                    if hook.get("command") == command:
-                        found = True
-            assert found, f"Hook not found for {event}"
-
-    def test_idempotent(self, tmp_path, monkeypatch):
+    def test_does_not_write_settings(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
-        # Install once
         runner.invoke(app, ["hooks", "install"])
-        # Install again
-        result = runner.invoke(app, ["hooks", "install"])
-        assert result.exit_code == 0
-        assert "already installed" in result.output
-
-        # Verify no duplicates
         f = tmp_path / ".claude" / "settings.json"
-        data = json.loads(f.read_text())
-        for event, command in OVERCODE_HOOKS:
-            count = 0
-            for entry in data["hooks"].get(event, []):
-                for hook in entry.get("hooks", []):
-                    if hook.get("command") == command:
-                        count += 1
-            assert count == 1, f"Duplicate hooks for {event}"
-
-    def test_project_flag(self, tmp_path, monkeypatch):
-        monkeypatch.chdir(tmp_path)
-        result = runner.invoke(app, ["hooks", "install", "--project"])
-        assert result.exit_code == 0
-        assert "project" in result.output
-        f = tmp_path / ".claude" / "settings.json"
-        assert f.exists()
-
-    def test_preserves_existing_settings(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
-        claude_dir = tmp_path / ".claude"
-        claude_dir.mkdir()
-        (claude_dir / "settings.json").write_text(json.dumps({"existingKey": True}))
-
-        result = runner.invoke(app, ["hooks", "install"])
-        assert result.exit_code == 0
-        data = json.loads((claude_dir / "settings.json").read_text())
-        assert data["existingKey"] is True
-
-    def test_invalid_json_error(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
-        claude_dir = tmp_path / ".claude"
-        claude_dir.mkdir()
-        (claude_dir / "settings.json").write_text("not json{{{")
-        result = runner.invoke(app, ["hooks", "install"])
-        assert result.exit_code == 1
-        assert "Error" in result.output
+        assert not f.exists()
 
 
 class TestHooksUninstall:
 
     def test_uninstalls_all_hooks(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
-        # Install first
-        runner.invoke(app, ["hooks", "install"])
+        _write_settings_with_hooks(tmp_path / ".claude" / "settings.json")
 
         result = runner.invoke(app, ["hooks", "uninstall"])
         assert result.exit_code == 0
@@ -109,8 +71,8 @@ class TestHooksUninstall:
 
     def test_uninstall_project_flag(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        # Install project hooks first
-        runner.invoke(app, ["hooks", "install", "--project"])
+        _write_settings_with_hooks(tmp_path / ".claude" / "settings.json")
+
         result = runner.invoke(app, ["hooks", "uninstall", "--project"])
         assert result.exit_code == 0
         assert "Removed" in result.output
@@ -121,7 +83,7 @@ class TestHooksStatus:
     def test_shows_installed_hooks(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
         monkeypatch.chdir(tmp_path)
-        runner.invoke(app, ["hooks", "install"])
+        _write_settings_with_hooks(tmp_path / ".claude" / "settings.json")
 
         result = runner.invoke(app, ["hooks", "status"])
         assert result.exit_code == 0
@@ -130,6 +92,13 @@ class TestHooksStatus:
         assert "Stop" in result.output
         assert "PermissionRequest" in result.output
         assert "SessionEnd" in result.output
+
+    def test_shows_deprecation_note(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["hooks", "status"])
+        assert result.exit_code == 0
+        assert "deprecated" in result.output.lower()
 
     def test_shows_not_installed(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -1574,6 +1574,178 @@ class TestSessionIdPrescribing:
 
 
 # =============================================================================
+# Settings injection (#435)
+# =============================================================================
+
+class TestSettingsInjection:
+    """Overcode hooks and permissions are injected via --settings flag."""
+
+    def test_launch_includes_settings_flag(self, tmp_path):
+        """Launch command includes --settings with JSON blob."""
+        mock_tmux = MockTmux()
+        tmux_manager = TmuxManager("agents", tmux=mock_tmux)
+        session_manager = SessionManager(state_dir=tmp_path, skip_git_detection=True)
+        launcher = ClaudeLauncher("agents", tmux_manager, session_manager)
+
+        launcher.launch(name="test-agent")
+
+        sent_commands = [k[2] for k in mock_tmux.sent_keys]
+        assert any("--settings" in cmd for cmd in sent_commands)
+
+    def test_settings_contains_hooks(self, tmp_path):
+        """Injected settings JSON contains all overcode hooks."""
+        import json
+        from overcode.hook_handler import OVERCODE_HOOKS
+
+        mock_tmux = MockTmux()
+        tmux_manager = TmuxManager("agents", tmux=mock_tmux)
+        session_manager = SessionManager(state_dir=tmp_path, skip_git_detection=True)
+        launcher = ClaudeLauncher("agents", tmux_manager, session_manager)
+
+        launcher.launch(name="test-agent")
+
+        sent_commands = [k[2] for k in mock_tmux.sent_keys]
+        # Find the --settings argument value
+        for cmd in sent_commands:
+            if "--settings" in cmd:
+                # The settings JSON is the token after --settings
+                # In the shlex-joined command string, find it
+                for event, _ in OVERCODE_HOOKS:
+                    assert event in cmd, f"Hook event {event} missing from --settings"
+                break
+
+    def test_settings_contains_safe_permissions(self, tmp_path):
+        """Injected settings include safe overcode permissions."""
+        from overcode.cli.perms import OVERCODE_SAFE_PERMS
+
+        mock_tmux = MockTmux()
+        tmux_manager = TmuxManager("agents", tmux=mock_tmux)
+        session_manager = SessionManager(state_dir=tmp_path, skip_git_detection=True)
+        launcher = ClaudeLauncher("agents", tmux_manager, session_manager)
+
+        launcher.launch(name="test-agent")
+
+        sent_commands = [k[2] for k in mock_tmux.sent_keys]
+        for cmd in sent_commands:
+            if "--settings" in cmd:
+                for perm in OVERCODE_SAFE_PERMS:
+                    assert perm in cmd, f"Permission {perm} missing from --settings"
+                break
+
+    def test_settings_excludes_punchy_permissions_by_default(self, tmp_path):
+        """Punchy permissions (launch, send) are NOT included by default."""
+        from overcode.cli.perms import OVERCODE_PUNCHY_PERMS
+
+        mock_tmux = MockTmux()
+        tmux_manager = TmuxManager("agents", tmux=mock_tmux)
+        session_manager = SessionManager(state_dir=tmp_path, skip_git_detection=True)
+        launcher = ClaudeLauncher("agents", tmux_manager, session_manager)
+
+        launcher.launch(name="test-agent")
+
+        sent_commands = [k[2] for k in mock_tmux.sent_keys]
+        for cmd in sent_commands:
+            if "--settings" in cmd:
+                for perm in OVERCODE_PUNCHY_PERMS:
+                    assert perm not in cmd, f"Punchy perm {perm} should not be in default --settings"
+                break
+
+    def test_hook_commands_use_absolute_path(self, tmp_path):
+        """Hook commands use resolved absolute path, not bare 'overcode'."""
+        mock_tmux = MockTmux()
+        tmux_manager = TmuxManager("agents", tmux=mock_tmux)
+        session_manager = SessionManager(state_dir=tmp_path, skip_git_detection=True)
+        launcher = ClaudeLauncher("agents", tmux_manager, session_manager)
+
+        launcher.launch(name="test-agent")
+
+        sent_commands = [k[2] for k in mock_tmux.sent_keys]
+        for cmd in sent_commands:
+            if "--settings" in cmd:
+                # The hook command should NOT be the bare "overcode hook-handler"
+                # It should be an absolute path or python -m invocation
+                assert '"overcode hook-handler"' not in cmd or \
+                    '/' in cmd.split('hook-handler')[0], \
+                    "Hook command should use absolute path"
+                break
+
+    def test_fork_includes_settings_flag(self, tmp_path):
+        """Fork command also includes --settings."""
+        mock_tmux = MockTmux()
+        tmux_manager = TmuxManager("agents", tmux=mock_tmux)
+        session_manager = SessionManager(state_dir=tmp_path, skip_git_detection=True)
+        launcher = ClaudeLauncher("agents", tmux_manager, session_manager)
+
+        source = launcher.launch(name="source", dangerously_skip_permissions=True)
+        session_manager.set_active_claude_session_id(source.id, "sess-123")
+        source = session_manager.get_session(source.id)
+
+        launcher.launch_fork(name="forked", source_session=source)
+
+        sent_commands = [k[2] for k in mock_tmux.sent_keys]
+        fork_cmds = [c for c in sent_commands if "--fork-session" in c]
+        assert len(fork_cmds) == 1
+        assert "--settings" in fork_cmds[0]
+
+
+class TestResolveOvercodeBin:
+    """Tests for _resolve_overcode_bin helper."""
+
+    def test_uses_which_when_available(self):
+        from overcode.launcher import _resolve_overcode_bin
+        with patch("overcode.launcher.shutil.which", return_value="/usr/local/bin/overcode"):
+            assert _resolve_overcode_bin() == "/usr/local/bin/overcode"
+
+    def test_falls_back_to_python_m(self):
+        from overcode.launcher import _resolve_overcode_bin
+        with patch("overcode.launcher.shutil.which", return_value=None):
+            result = _resolve_overcode_bin()
+            assert result.endswith("-m overcode.cli")
+            assert sys.executable in result
+
+
+class TestBuildLaunchSettings:
+    """Tests for _build_launch_settings helper."""
+
+    def test_all_hook_events_present(self):
+        from overcode.launcher import _build_launch_settings
+        from overcode.hook_handler import OVERCODE_HOOKS
+
+        settings = _build_launch_settings("/usr/local/bin/overcode")
+        for event, _ in OVERCODE_HOOKS:
+            assert event in settings["hooks"]
+
+    def test_hook_commands_use_provided_bin(self):
+        from overcode.launcher import _build_launch_settings
+
+        settings = _build_launch_settings("/opt/custom/overcode")
+        for event, entries in settings["hooks"].items():
+            for entry in entries:
+                for hook in entry["hooks"]:
+                    assert hook["command"] == "/opt/custom/overcode hook-handler"
+
+    def test_safe_perms_only_by_default(self):
+        from overcode.launcher import _build_launch_settings
+        from overcode.cli.perms import OVERCODE_SAFE_PERMS, OVERCODE_PUNCHY_PERMS
+
+        settings = _build_launch_settings("/usr/local/bin/overcode")
+        allow = settings["permissions"]["allow"]
+        for p in OVERCODE_SAFE_PERMS:
+            assert p in allow
+        for p in OVERCODE_PUNCHY_PERMS:
+            assert p not in allow
+
+    def test_includes_punchy_when_requested(self):
+        from overcode.launcher import _build_launch_settings
+        from overcode.cli.perms import OVERCODE_SAFE_PERMS, OVERCODE_PUNCHY_PERMS
+
+        settings = _build_launch_settings("/usr/local/bin/overcode", include_punchy_perms=True)
+        allow = settings["permissions"]["allow"]
+        for p in OVERCODE_SAFE_PERMS + OVERCODE_PUNCHY_PERMS:
+            assert p in allow
+
+
+# =============================================================================
 # Run tests directly
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Fixes #435. Instead of requiring `overcode hooks install` / `overcode perms install` to pre-populate `~/.claude/settings.json`, overcode now injects hooks and permissions at launch time via Claude Code's `--settings` flag.

- **`_resolve_overcode_bin()`** resolves the absolute path to `overcode` at launch time (`shutil.which` with `sys.executable -m` fallback), so hooks never hit `command not found` regardless of how overcode was installed
- **`_build_launch_settings()`** generates the `--settings` JSON blob with all 8 hook events and safe permissions
- **`--settings <json>`** is passed in `_build_claude_command` for both `launch()` and `launch_fork()` paths
- `overcode hooks install` and `overcode perms install` are deprecated (print a notice and exit) — uninstall/status remain for cleaning up legacy installs
- TUI message updated to reflect automatic injection

This is additive — user/project settings still load normally, overcode's hooks layer on top.

## Test plan

- [x] All 3285 unit tests pass (12 new tests for settings injection + helpers)
- [ ] Manual: `overcode launch -n test` and verify hooks fire without `overcode hooks install`
- [ ] Manual: open a standalone `claude` session and verify no overcode hook errors
- [ ] Manual: `overcode hooks install` shows deprecation notice
- [ ] Manual: `overcode hooks status` shows deprecation note

🤖 Generated with [Claude Code](https://claude.com/claude-code)