### PR TITLE
#433 Inherit parent settings for child agents launched via overcode launch

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -27,7 +27,10 @@ overcode launch --name <name> [options]
 | `--claude-arg` | | Extra Claude CLI flag (repeatable). Each value is a space-separated flag+value string |
 | `--budget` | `-b` | Cost budget in USD (deducted from parent if parent has budget) |
 | `--wrapper` | `-w` | Wrapper script: path or name from `~/.overcode/wrappers/` (e.g., `devcontainer`) |
+| `--no-inherit` | | Don't inherit settings from the parent agent (see below) |
 | `--session` | | Tmux session name (default: `agents`) |
+
+**Parent settings inheritance (#433):** when launched from within an agent (or with `--parent`), the child inherits the parent's `provider`, `model`, `wrapper`, agent-teams setting, and permission mode for any of those not given explicitly. Resolution order is: explicit flag > parent setting > `new_agent_defaults` in `~/.overcode/config.yaml` > built-in default. So a parent pinned to Bedrock spawns Bedrock children unless told otherwise. Use `--no-inherit` to skip the parent and resolve from config defaults only.
 
 **Examples:**
 ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,7 +145,7 @@ new_agent_defaults:
   wrapper: ""                 # Wrapper script name or path (e.g., "devcontainer")
 ```
 
-These apply to agents created via both the CLI (`overcode launch`) and the TUI (`n` key). CLI flags override config defaults.
+These apply to agents created via both the CLI (`overcode launch`) and the TUI (`n` key). CLI flags override config defaults, and for child agents the parent's settings take precedence over config defaults (#433): explicit flag > parent setting > config default > built-in default. Use `--no-inherit` to skip the parent.
 
 Setting `wrapper: devcontainer` makes all new agents launch inside a Docker container by default. See the [Wrappers Guide](wrappers.md) for details.
 

--- a/src/overcode/cli/agent.py
+++ b/src/overcode/cli/agent.py
@@ -234,6 +234,13 @@ def launch(
         Optional[str],
         typer.Option("--wrapper", "-w", help="Wrapper script (path or name from ~/.overcode/wrappers/)"),
     ] = None,
+    no_inherit: Annotated[
+        bool,
+        typer.Option(
+            "--no-inherit",
+            help="Don't inherit provider/model/wrapper/permissions from the parent agent (#433)",
+        ),
+    ] = False,
     sister: Annotated[
         Optional[str],
         typer.Option("--sister", "-S", help="Launch on a remote sister machine (by name from config)"),
@@ -292,21 +299,12 @@ def launch(
     # Parse oversight policy
     oversight_policy, oversight_timeout_seconds = _parse_oversight_policy(on_stuck, oversight_timeout)
 
-    # Resolve provider: CLI flag > config default > "web"
-    from ..config import get_new_agent_defaults
-    agent_defaults = get_new_agent_defaults()
-
-    resolved_provider = provider
-    if resolved_provider is None:
-        resolved_provider = agent_defaults.get("provider", "web")
-    if resolved_provider not in ("web", "bedrock"):
-        rprint(f"[red]Error: Invalid provider '{resolved_provider}'. Use: web, bedrock[/red]")
+    # Provider/wrapper resolution (CLI flag > parent settings > config
+    # default) happens in the launcher (#433); only validate the explicit
+    # flag here for a clean error message.
+    if provider is not None and provider not in ("web", "bedrock"):
+        rprint(f"[red]Error: Invalid provider '{provider}'. Use: web, bedrock[/red]")
         raise typer.Exit(code=1)
-
-    # Resolve wrapper: CLI flag > config default > None
-    resolved_wrapper = wrapper
-    if resolved_wrapper is None:
-        resolved_wrapper = agent_defaults.get("wrapper") or None
 
     # Default to current directory if not specified
     working_dir = directory if directory else os.getcwd()
@@ -326,8 +324,9 @@ def launch(
         budget_usd=budget,
         claude_agent=agent,
         model=model,
-        provider=resolved_provider,
-        wrapper=resolved_wrapper,
+        provider=provider,
+        wrapper=wrapper,
+        inherit_parent_settings=not no_inherit,
     )
 
     if result:
@@ -344,10 +343,12 @@ def launch(
             rprint(f"  Agent: {agent}")
         if teams:
             rprint("  Agent teams: enabled")
-        if resolved_wrapper:
-            rprint(f"  Wrapper: {resolved_wrapper}")
-        if resolved_provider != "web":
-            rprint(f"  Provider: {resolved_provider}")
+        if result.wrapper:
+            rprint(f"  Wrapper: {result.wrapper}")
+        if result.provider != "web":
+            rprint(f"  Provider: {result.provider}")
+        if result.model and not model:
+            rprint(f"  Model: {result.model} (inherited)")
         if budget is not None and budget > 0:
             rprint(f"  Budget: ${budget:.2f}")
 

--- a/src/overcode/launcher.py
+++ b/src/overcode/launcher.py
@@ -276,8 +276,9 @@ class ClaudeLauncher:
         budget_usd: Optional[float] = None,
         claude_agent: Optional[str] = None,
         model: Optional[str] = None,
-        provider: str = "web",
+        provider: Optional[str] = None,
         wrapper: Optional[str] = None,
+        inherit_parent_settings: bool = True,
     ) -> Optional[Session]:
         """
         Launch an interactive Claude Code session in a tmux window.
@@ -293,9 +294,13 @@ class ClaudeLauncher:
                 If not set, auto-detects from OVERCODE_SESSION_NAME env var.
             allowed_tools: Comma-separated tool list for --allowedTools
             extra_claude_args: Extra Claude CLI flags (each a space-separated string)
-            provider: API provider — "web" (Claude.ai OAuth) or "bedrock" (AWS Bedrock)
+            provider: API provider — "web" (Claude.ai OAuth) or "bedrock" (AWS Bedrock).
+                None resolves via parent inheritance, then config defaults, then "web".
             wrapper: Optional wrapper script path. The wrapper receives the claude
                 command as arguments and OVERCODE_WRAPPER_DIR for the working directory.
+            inherit_parent_settings: If True (default), provider/model/wrapper/
+                agent_teams/permission mode not explicitly set are inherited from
+                the parent agent (#433).
 
         Returns:
             Session object if successful, None otherwise
@@ -333,6 +338,37 @@ class ClaudeLauncher:
             if parent_depth + 1 >= self.MAX_HIERARCHY_DEPTH:
                 print(f"Cannot launch: maximum hierarchy depth ({self.MAX_HIERARCHY_DEPTH}) exceeded")
                 return None
+
+        # Settings resolution (#433): explicit arg > parent setting > config
+        # default > built-in default. Children inherit the parent's provider,
+        # model, wrapper, agent_teams, and permission mode so a bedrock-pinned
+        # or model-constrained parent doesn't spawn children on different
+        # infrastructure. Opt out with inherit_parent_settings=False.
+        if parent_session and inherit_parent_settings:
+            if provider is None:
+                provider = parent_session.provider
+            if model is None:
+                model = parent_session.model
+            if wrapper is None:
+                wrapper = parent_session.wrapper
+            if not agent_teams:
+                agent_teams = parent_session.agent_teams
+            if not skip_permissions and not dangerously_skip_permissions:
+                if parent_session.permissiveness_mode == "bypass":
+                    dangerously_skip_permissions = True
+                elif parent_session.permissiveness_mode == "permissive":
+                    skip_permissions = True
+
+        from .config import get_new_agent_defaults
+        agent_defaults = get_new_agent_defaults()
+        if provider is None:
+            provider = agent_defaults.get("provider") or "web"
+        if wrapper is None:
+            wrapper = agent_defaults.get("wrapper") or None
+
+        if provider not in ("web", "bedrock"):
+            print(f"Cannot launch: invalid provider '{provider}'. Use: web, bedrock")
+            return None
 
         # Resolve wrapper if specified
         resolved_wrapper = None

--- a/src/overcode/tui.py
+++ b/src/overcode/tui.py
@@ -3186,7 +3186,7 @@ class SupervisorTUI(
                     dangerously_skip_permissions=message.bypass_permissions,
                     agent_teams=message.agent_teams,
                     claude_agent=message.claude_agent,
-                    provider=message.provider or "web",
+                    provider=message.provider,
                     wrapper=message.wrapper,
                     extra_claude_args=message.extra_claude_args or None,
                 )

--- a/src/overcode/web_control_api.py
+++ b/src/overcode/web_control_api.py
@@ -168,7 +168,7 @@ def launch_agent(
     name: str,
     prompt: Optional[str] = None,
     permissions: str = "normal",
-    provider: str = "web",
+    provider: Optional[str] = None,
 ) -> dict:
     """Launch a new agent."""
     import io

--- a/src/overcode/web_server.py
+++ b/src/overcode/web_server.py
@@ -59,7 +59,7 @@ _FIXED_CONTROL_ROUTES = {
     ("POST", "/api/agents/launch"): lambda api, ts, body: api.launch_agent(
         ts, directory=body.get("directory", "."), name=body.get("name", ""),
         prompt=body.get("prompt"), permissions=body.get("permissions", "normal"),
-        provider=body.get("provider", "web"),
+        provider=body.get("provider"),
     ),
     ("POST", "/api/agents/transport"): lambda api, ts, body: api.transport_all(ts),
     ("POST", "/api/agents/cleanup"): lambda api, ts, body: api.cleanup_agents(

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -1011,6 +1011,129 @@ class TestLauncherHierarchy:
         assert any("OVERCODE_PARENT_NAME=env-parent" in cmd for cmd in child_cmd)
 
 
+class TestParentSettingsInheritance:
+    """Children inherit launch settings from their parent agent (#433)."""
+
+    def _make_launcher(self, tmp_path):
+        mock_tmux = MockTmux()
+        tmux_manager = TmuxManager("agents", tmux=mock_tmux)
+        session_manager = SessionManager(state_dir=tmp_path, skip_git_detection=True)
+        launcher = ClaudeLauncher(
+            tmux_session="agents",
+            tmux_manager=tmux_manager,
+            session_manager=session_manager,
+        )
+        return launcher, mock_tmux
+
+    def test_child_inherits_provider_and_model(self, tmp_path):
+        launcher, mock_tmux = self._make_launcher(tmp_path)
+
+        parent = launcher.launch(name="parent", provider="bedrock", model="sonnet")
+        assert parent is not None
+
+        child = launcher.launch(name="child", parent_name="parent")
+        assert child is not None
+        assert child.provider == "bedrock"
+        assert child.model == "sonnet"
+
+        # Bedrock env vars propagate to the child's shell command
+        sent_commands = [k[2] for k in mock_tmux.sent_keys]
+        child_cmd = [c for c in sent_commands if "OVERCODE_SESSION_NAME=child" in c]
+        assert any("CLAUDE_CODE_USE_BEDROCK=1" in cmd for cmd in child_cmd)
+        assert any("--model sonnet" in cmd for cmd in child_cmd)
+
+    def test_explicit_args_override_inheritance(self, tmp_path):
+        launcher, _ = self._make_launcher(tmp_path)
+
+        launcher.launch(name="parent", provider="bedrock", model="sonnet")
+        child = launcher.launch(
+            name="child", parent_name="parent", provider="web", model="haiku"
+        )
+        assert child.provider == "web"
+        assert child.model == "haiku"
+
+    def test_no_inherit_opts_out(self, tmp_path):
+        launcher, _ = self._make_launcher(tmp_path)
+
+        launcher.launch(name="parent", provider="bedrock", model="sonnet")
+        with patch("overcode.config.get_new_agent_defaults", return_value={
+            "bypass_permissions": False, "agent_teams": False,
+            "provider": "web", "wrapper": "",
+        }):
+            child = launcher.launch(
+                name="child", parent_name="parent", inherit_parent_settings=False
+            )
+        assert child.provider == "web"
+        assert child.model is None
+
+    def test_child_inherits_wrapper(self, tmp_path):
+        launcher, _ = self._make_launcher(tmp_path)
+
+        wrapper_path = tmp_path / "wrap.sh"
+        wrapper_path.write_text("#!/bin/sh\nexec \"$@\"\n")
+        wrapper_path.chmod(0o755)
+
+        parent = launcher.launch(name="parent", wrapper=str(wrapper_path))
+        assert parent.wrapper == str(wrapper_path)
+
+        child = launcher.launch(name="child", parent_name="parent")
+        assert child.wrapper == str(wrapper_path)
+
+    def test_child_inherits_permission_mode(self, tmp_path):
+        launcher, mock_tmux = self._make_launcher(tmp_path)
+
+        launcher.launch(name="parent", dangerously_skip_permissions=True)
+        child = launcher.launch(name="child", parent_name="parent")
+        assert child.permissiveness_mode == "bypass"
+
+        sent_commands = [k[2] for k in mock_tmux.sent_keys]
+        child_cmd = [c for c in sent_commands if "OVERCODE_SESSION_NAME=child" in c]
+        assert any("--dangerously-skip-permissions" in cmd for cmd in child_cmd)
+
+    def test_explicit_permission_flag_overrides_parent(self, tmp_path):
+        launcher, _ = self._make_launcher(tmp_path)
+
+        launcher.launch(name="parent", dangerously_skip_permissions=True)
+        child = launcher.launch(
+            name="child", parent_name="parent", skip_permissions=True
+        )
+        assert child.permissiveness_mode == "permissive"
+
+    def test_child_inherits_agent_teams(self, tmp_path):
+        launcher, _ = self._make_launcher(tmp_path)
+
+        launcher.launch(name="parent", agent_teams=True)
+        child = launcher.launch(name="child", parent_name="parent")
+        assert child.agent_teams is True
+
+    def test_auto_detected_parent_inherits(self, tmp_path):
+        """Inheritance also applies when the parent is auto-detected from env."""
+        launcher, _ = self._make_launcher(tmp_path)
+
+        launcher.launch(name="parent", provider="bedrock")
+        with patch.dict("os.environ", {"OVERCODE_SESSION_NAME": "parent"}):
+            child = launcher.launch(name="child")
+        assert child.provider == "bedrock"
+
+    def test_config_default_when_no_parent(self, tmp_path):
+        launcher, _ = self._make_launcher(tmp_path)
+
+        with patch("overcode.config.get_new_agent_defaults", return_value={
+            "bypass_permissions": False, "agent_teams": False,
+            "provider": "bedrock", "wrapper": "",
+        }):
+            session = launcher.launch(name="solo")
+        assert session.provider == "bedrock"
+
+    def test_invalid_provider_rejected(self, tmp_path, capsys):
+        launcher, _ = self._make_launcher(tmp_path)
+
+        session = launcher.launch(name="bad", provider="azure")
+        assert session is None
+        captured = capsys.readouterr()
+        assert "invalid provider" in captured.out.lower()
+
+
 class TestCascadeKill:
     """Test cascade kill functionality."""
 

--- a/tests/unit/test_web_control_api.py
+++ b/tests/unit/test_web_control_api.py
@@ -243,7 +243,7 @@ class TestLaunchAgent:
             initial_prompt=None,
             skip_permissions=False,
             dangerously_skip_permissions=False,
-            provider="web",
+            provider=None,
         )
 
     @patch(LAUNCHER_PATH)
@@ -262,7 +262,7 @@ class TestLaunchAgent:
             initial_prompt=None,
             skip_permissions=True,
             dangerously_skip_permissions=False,
-            provider="web",
+            provider=None,
         )
 
     def test_invalid_permissions_raises_400(self):

--- a/tests/unit/test_web_server.py
+++ b/tests/unit/test_web_server.py
@@ -1212,7 +1212,7 @@ class TestDispatchControl:
 
         mock_fn.assert_called_once_with(
             "test-session", directory="/tmp", name="new-agent",
-            prompt="test", permissions="normal", provider="web"
+            prompt="test", permissions="normal", provider=None
         )
 
     def test_post_sleep_agent(self):


### PR DESCRIPTION
Closes #433.

## What

When a child agent is launched from inside a parent (auto-detected via `OVERCODE_SESSION_NAME`, or with `--parent`), it now inherits the parent's launch settings instead of silently falling back to defaults. Resolution order for every setting:

**explicit flag > parent setting > `new_agent_defaults` config > built-in default**

Inherited settings: `provider` (web/bedrock), `model`, `wrapper`, `agent_teams`, and permission mode (bypass/permissive). A new `--no-inherit` flag opts out, falling back to config defaults.

## How

- `ClaudeLauncher.launch()` takes `provider: Optional[str]` and `inherit_parent_settings: bool = True`, and does the full resolution chain after parent detection — so launch/CLI/TUI/web-API all behave the same. It also validates the resolved provider.
- The CLI no longer pre-resolves config defaults (which would have masked parent inheritance); it only validates an explicitly-passed `--provider`.
- TUI and web control API pass `provider` through unresolved instead of pinning `"web"`.
- Docs updated (cli-reference.md, configuration.md); 10 new unit tests covering inheritance, explicit override, opt-out, env-detected parents, config fallback, and invalid-provider rejection.

Per the issue's design questions: inheritance is opt-out (`--no-inherit`) rather than opt-in, and task-specific settings (`--allowed-tools`, `--claude-arg`, `--agent`, prompt, budget) are deliberately NOT inherited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)